### PR TITLE
Frame lowering optimizations

### DIFF
--- a/llvm/lib/Target/Mips/MipsMachineFunction.cpp
+++ b/llvm/lib/Target/Mips/MipsMachineFunction.cpp
@@ -201,3 +201,19 @@ int MipsFunctionInfo::getMoveF64ViaSpillFI(MachineFunction &MF,
 }
 
 void MipsFunctionInfo::anchor() {}
+
+unsigned MipsFunctionInfo::getCalleeSavedStackSize() {
+  return CalleeSavedStackSize;
+}
+
+void MipsFunctionInfo::setCalleeSavedStackSize(unsigned Size) {
+  CalleeSavedStackSize = Size;
+}
+
+bool MipsFunctionInfo::isTwoStepStackSetup(MachineFunction &MF) {
+
+  const MipsSubtarget &STI =
+      *static_cast<const MipsSubtarget *>(&MF.getSubtarget());
+
+  return (MF.getFrameInfo().getStackSize() > 4096) && STI.hasNanoMips();
+}

--- a/llvm/lib/Target/Mips/MipsMachineFunction.h
+++ b/llvm/lib/Target/Mips/MipsMachineFunction.h
@@ -108,6 +108,9 @@ public:
       JumpTableEntryInfo[Idx]->Signed = Sign;
     }
   }
+  unsigned getCalleeSavedStackSize();
+  void setCalleeSavedStackSize(unsigned Size);
+  bool isTwoStepStackSetup(MachineFunction &MF);
 
 private:
   virtual void anchor();
@@ -168,6 +171,7 @@ private:
   };
 
   SmallVector<NanoMipsJumpTableInfo *, 2> JumpTableEntryInfo;
+  unsigned CalleeSavedStackSize = 0;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
@@ -461,8 +461,8 @@ bool MipsSEDAGToDAGISel::selectIntAddrLSL2MM(SDValue Addr, SDValue &Base,
 
 bool MipsSEDAGToDAGISel::selectIntAddrSImm9(SDValue Addr, SDValue &Base,
                                             SDValue &Offset) const {
-  return selectAddrFrameIndex(Addr, Base, Offset) ||
-    selectAddrFrameIndexOffset(Addr, Base, Offset, 9);
+  return selectAddrFrameIndexOffset(Addr, Base, Offset, 9) &&
+         !isa<FrameIndexSDNode>(Base);
 }
 
 bool MipsSEDAGToDAGISel::selectIntAddrSImm10(SDValue Addr, SDValue &Base,
@@ -541,7 +541,8 @@ bool MipsSEDAGToDAGISel::selectAddrFrameIndexUOffset(
 
 bool MipsSEDAGToDAGISel::selectIntAddrUImm12(SDValue Addr, SDValue &Base,
                                              SDValue &Offset) const {
-  return selectAddrFrameIndexUOffset(Addr, Base, Offset, 12, 0);
+  return selectAddrFrameIndex(Addr, Base, Offset) ||
+         selectAddrFrameIndexUOffset(Addr, Base, Offset, 12, 0);
 }
 
 // A load/store 'x' indexed (reg + reg)

--- a/llvm/lib/Target/Mips/MipsSERegisterInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSERegisterInfo.cpp
@@ -220,7 +220,18 @@ void MipsSERegisterInfo::eliminateFI(MachineBasicBlock::iterator II,
   bool IsKill = false;
   int64_t Offset;
 
-  Offset = SPOffset + (int64_t)StackSize;
+  if (MipsFI->isTwoStepStackSetup(MF)) {
+
+    int64_t CalleeSavedStackSize = MipsFI->getCalleeSavedStackSize();
+
+    if (FrameIndex >= MinCSFI && FrameIndex <= MaxCSFI)
+      Offset = SPOffset + (int64_t)CalleeSavedStackSize;
+    else
+      Offset = SPOffset + StackSize;
+
+  } else
+    Offset = SPOffset + (int64_t)StackSize;
+
   Offset += MI.getOperand(OpNo + 1).getImm();
 
   LLVM_DEBUG(errs() << "Offset     : " << Offset << "\n"

--- a/llvm/test/CodeGen/Mips/nanomips/frame_pointer.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/frame_pointer.ll
@@ -1,0 +1,121 @@
+; RUN: llc -mtriple=nanomips -asm-show-inst -verify-machineinstrs < %s | FileCheck %s
+
+; Check if fp is set correctly if function wants to use it. 
+; We want it to point to -4096 from the beginning of the stack.
+define void @test1(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #0 {
+entry:
+  ; CHECK: save	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+  ; CHECK: addiu	$fp, $sp, -4032
+  ; CHECK: sw	$a0, 32($sp)
+  ; CHECK: restore.jrc	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4 
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca i32, align 4
+  %c.addr = alloca i32, align 4
+  %d.addr = alloca i32, align 4
+  %e.addr = alloca i32, align 4
+  %f.addr = alloca i32, align 4
+  store i32 %a, i32* %a.addr, align 4
+  store i32 %b, i32* %b.addr, align 4
+  store i32 %c, i32* %c.addr, align 4
+  store i32 %d, i32* %d.addr, align 4
+  store i32 %e, i32* %e.addr, align 4
+  store i32 %f, i32* %f.addr, align 4
+  call void asm sideeffect "", "~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"()
+  
+  ret void
+}
+
+; Check if offsets after fp setup are relative to fp if varible-sized 
+; objects are present in function.
+declare void @callee2(i8*)
+define void @test2(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #0 {
+entry:
+  ; CHECK: save	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+  ; CHECK: addiu	$fp, $sp, -4032
+  ; CHECK: sw	$a0, 4064($fp)
+  ; CHECK: restore.jrc	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca i32, align 4
+  %c.addr = alloca i32, align 4
+  %d.addr = alloca i32, align 4
+  %e.addr = alloca i32, align 4
+  %f.addr = alloca i32, align 4
+  store i32 %a, i32* %a.addr, align 4
+  store i32 %b, i32* %b.addr, align 4
+  store i32 %c, i32* %c.addr, align 4
+  store i32 %d, i32* %d.addr, align 4
+  store i32 %e, i32* %e.addr, align 4
+  store i32 %f, i32* %f.addr, align 4
+  
+  %0 = alloca i8, i32 %a  
+  call void @callee2(i8* %0)
+
+  call void asm sideeffect "", "~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"()
+  
+  ret void
+}
+
+; Check if offsets after fp setup stays relative to sp if 
+; function needs stack realignment
+declare void @callee3(i32*)
+define void @test3(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #0 {
+entry:
+  ; CHECK: save	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+  ; CHECK: addiu	$fp, $sp, -4032
+  ; CHECK: sw	$a0, 32($sp)
+  ; CHECK: restore.jrc	64, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca i32, align 4
+  %c.addr = alloca i32, align 4
+  %d.addr = alloca i32, align 4
+  %e.addr = alloca i32, align 4
+  %f.addr = alloca i32, align 4
+  store i32 %a, i32* %a.addr, align 4
+  store i32 %b, i32* %b.addr, align 4
+  store i32 %c, i32* %c.addr, align 4
+  store i32 %d, i32* %d.addr, align 4
+  store i32 %e, i32* %e.addr, align 4
+  store i32 %f, i32* %f.addr, align 4
+  
+  %0 = alloca i32, align 64
+  call void @callee3(i32 *%0)
+
+  call void asm sideeffect "", "~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"()
+  
+  ret void
+}
+
+; Check if offsets after fp setup are relative to BasePtr if varible-sized 
+; objects are present in function and function needs stack realignment
+declare void @callee4(i8*, i32*)
+define void @test4(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f) #0 {
+entry:
+  ; CHECK: save	192, $fp, $ra, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+  ; CHECK: addiu	$fp, $sp, -3904
+  ; CHECK: sw	$a0, 148($s7)
+  ; CHECK: restore.jrc	192, $fp, $ra, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca i32, align 4
+  %c.addr = alloca i32, align 4
+  %d.addr = alloca i32, align 4
+  %e.addr = alloca i32, align 4
+  %f.addr = alloca i32, align 4
+  store i32 %a, i32* %a.addr, align 4
+  store i32 %b, i32* %b.addr, align 4
+  store i32 %c, i32* %c.addr, align 4
+  store i32 %d, i32* %d.addr, align 4
+  store i32 %e, i32* %e.addr, align 4
+  store i32 %f, i32* %f.addr, align 4
+  
+  %0 = alloca i8, i32 %a
+  %1 = alloca i32, align 64
+  call void @callee4(i8* %0, i32 *%1)
+
+  call void asm sideeffect "", "~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"()
+  
+  ret void
+}
+
+attributes #0 = {"frame-pointer"="all"}
+!llvm.module.flags = !{!0}
+!0 = !{i32 7, !"frame-pointer", i32 2}

--- a/llvm/test/CodeGen/Mips/nanomips/saverestore.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/saverestore.ll
@@ -7,17 +7,6 @@ define void @test() {
 ; CHECK: restore.jrc 32, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
 }
 
-; Make sure that SAVE/RESTORE instructions are not used when the offset is larger than 4092.
-define void @test2() {
-; CHECK-NOT: save
-  %foo = alloca [4096 x i8], align 1
-  %1 = getelementptr inbounds [4096 x i8], [4096 x i8]* %foo, i32 0, i32 0
-  call void asm sideeffect "", "r,~{$16},~{$17},~{$18},~{$19},~{$20},~{$21},~{$23},~{$22},~{$1}"(i8* %1)
-  ret void
-; CHECK-NOT: restore.jrc
-; CHECK-NOT: restore
-}
-
 ; Make sure that SAVE/SAVE combination is used when incoming arguments need to
 ; be stored on the stack. First SAVE to move the stack pointer to where s-regs
 ; need to be stored and second SAVE to actually save the registers. Same logic

--- a/llvm/test/CodeGen/Mips/nanomips/saverestore_with_register_gap.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/saverestore_with_register_gap.ll
@@ -1,0 +1,43 @@
+; RUN: llc -mtriple=nanomips -asm-show-inst -verify-machineinstrs < %s | FileCheck %s
+
+; Make sure that SAVE/RESTORE instructions are working even though there 
+; is a gap in the callee-saved register sequence.
+define void @test1() {
+; CHECK: save 32, $s0, $s1, $s2, $s3, $s4
+  call void asm sideeffect "", "~{$16},~{$18},~{$20},~{$1}"() ret void
+; CHECK: restore.jrc 32, $s0, $s1, $s2, $s3, $s4
+}
+
+define void @test2() {
+; CHECK: save	48, $fp, $ra, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+  call void asm sideeffect "", "~{$16},~{$23},~{$30},~{$1}"() ret void
+; CHECK: restore.jrc	48, $fp, $ra, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+}
+
+; Make sure to generate correct SAVE/RESTOR sp offset in case there was a gap
+; in callee-saved register sequence and there are more things to be stored on 
+; stack after storing values from callee-saved registers. For example values 
+; from ax registers, used to pass function arguments, can be stored on stack 
+; after values from callee-saved registers.
+define void @test3(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
+  
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca i32, align 4
+  %c.addr = alloca i32, align 4
+  %d.addr = alloca i32, align 4
+  %e.addr = alloca i32, align 4
+  %f.addr = alloca i32, align 4
+  %g.addr = alloca i32, align 4
+  %h.addr = alloca i32, align 4
+  store i32 %a, i32* %a.addr, align 4
+  store i32 %b, i32* %b.addr, align 4
+  store i32 %c, i32* %c.addr, align 4
+  store i32 %d, i32* %d.addr, align 4
+  store i32 %e, i32* %e.addr, align 4
+  store i32 %f, i32* %f.addr, align 4
+  store i32 %g, i32* %g.addr, align 4
+  store i32 %h, i32* %h.addr, align 4  
+	; CHECK: save	64, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+  call void asm sideeffect "", "~{$16},~{$23},~{$1}"() ret void  
+	; CHECK: restore.jrc	64, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
+}

--- a/llvm/test/CodeGen/Mips/nanomips/stack_realignment.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/stack_realignment.ll
@@ -1,0 +1,13 @@
+; RUN: llc -mtriple=nanomips -asm-show-inst -verify-machineinstrs < %s | FileCheck %s
+
+; Check if stack realignment is done using INS instruction 
+; if function needs it.
+declare void @callee(i32*)
+define void @test() {
+entry:
+  ; CHECK: ins $sp, $zero, 0, 6
+  %0 = alloca i32, align 64
+  call void @callee(i32 *%0)
+  ret void
+}
+

--- a/llvm/test/CodeGen/Mips/nanomips/two-step-stack-setup.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/two-step-stack-setup.ll
@@ -1,0 +1,36 @@
+; RUN: llc -mtriple=nanomips -asm-show-inst -verify-machineinstrs < %s | FileCheck %s
+
+; Check if stack setup is splitted into two-step setup when sp
+; offset is larger than 4096
+define void @test1() {
+  ; CHECK: save	32, $s0, $s1, $s2, $s3, $s4
+  ; CHECK: addiu $sp, $sp, -4096  
+  %foo = alloca [4096 x i8], align 1
+  %1 = getelementptr inbounds [4096 x i8], [4096 x i8]* %foo, i32 0, i32 0
+  call void asm sideeffect "", "r,~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"(i8* %1)
+  ret void
+  ; CHECK: addiu $sp, $sp, 4096
+  ; CHECK: restore.jrc	32, $s0, $s1, $s2, $s3, $s4
+}
+
+; Check if there are two instructions for storing sp in fp
+; if function uses fp and two-step stack setup is present
+define void @test2() #0 {
+  ; CHECK: save	32, $fp, $ra, $s0, $s1, $s2, $s3, $s4  
+  ; CHECK: or $fp, $sp, $zero
+  ; CHECK: addiu $sp, $sp, -4096
+  ; CHECK: or $fp, $sp, $zero
+  %foo = alloca [4096 x i8], align 1
+  %1 = getelementptr inbounds [4096 x i8], [4096 x i8]* %foo, i32 0, i32 0
+  call void asm sideeffect "", "r,~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"(i8* %1)
+  ret void
+  ; CHECK: addiu $sp, $sp, 4096
+  ; CHECK: restore.jrc	32, $fp, $ra, $s0, $s1, $s2, $s3, $s4
+}
+
+attributes #0 = { "frame-pointer"="all"}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 7, !"frame-pointer", i32 2}
+

--- a/llvm/test/CodeGen/Mips/nanomips/two-step-stack-setup.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/two-step-stack-setup.ll
@@ -12,25 +12,3 @@ define void @test1() {
   ; CHECK: addiu $sp, $sp, 4096
   ; CHECK: restore.jrc	32, $s0, $s1, $s2, $s3, $s4
 }
-
-; Check if there are two instructions for storing sp in fp
-; if function uses fp and two-step stack setup is present
-define void @test2() #0 {
-  ; CHECK: save	32, $fp, $ra, $s0, $s1, $s2, $s3, $s4  
-  ; CHECK: or $fp, $sp, $zero
-  ; CHECK: addiu $sp, $sp, -4096
-  ; CHECK: or $fp, $sp, $zero
-  %foo = alloca [4096 x i8], align 1
-  %1 = getelementptr inbounds [4096 x i8], [4096 x i8]* %foo, i32 0, i32 0
-  call void asm sideeffect "", "r,~{$16},~{$17},~{$18},~{$19},~{$20},~{$1}"(i8* %1)
-  ret void
-  ; CHECK: addiu $sp, $sp, 4096
-  ; CHECK: restore.jrc	32, $fp, $ra, $s0, $s1, $s2, $s3, $s4
-}
-
-attributes #0 = { "frame-pointer"="all"}
-
-!llvm.module.flags = !{!0}
-
-!0 = !{i32 7, !"frame-pointer", i32 2}
-


### PR DESCRIPTION
Enable save/restore generation when there is a gap between registers by inserting the missing ones at the moment when spill slots for callee-saved registers are assigned.