### PR TITLE
Jump table optimization

### DIFF
--- a/clang/docs/ClangCommandLineReference.rst
+++ b/clang/docs/ClangCommandLineReference.rst
@@ -3423,6 +3423,10 @@ Enable MT ASE (MIPS only)
 
 .. option:: -mxgot, -mno-xgot
 
+Disable jump table optimization (nanoMIPS only)
+
+.. option:: -mjump-table-opt, -mno-jump-table-opt
+
 PowerPC
 -------
 .. option:: -maltivec, -mno-altivec

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3485,6 +3485,8 @@ def mmicromips : Flag<["-"], "mmicromips">, Group<m_mips_Features_Group>;
 def mno_micromips : Flag<["-"], "mno-micromips">, Group<m_mips_Features_Group>;
 def mxgot : Flag<["-"], "mxgot">, Group<m_mips_Features_Group>;
 def mno_xgot : Flag<["-"], "mno-xgot">, Group<m_mips_Features_Group>;
+def mjump_table_opt : Flag<["-"], "mjump-table-opt">, Group<m_mips_Features_Group>;
+def mno_jump_table_opt : Flag<["-"], "mno-jump-table-opt">, Group<m_mips_Features_Group>;
 def mldc1_sdc1 : Flag<["-"], "mldc1-sdc1">, Group<m_mips_Features_Group>;
 def mno_ldc1_sdc1 : Flag<["-"], "mno-ldc1-sdc1">, Group<m_mips_Features_Group>;
 def mcheck_zero_division : Flag<["-"], "mcheck-zero-division">,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -580,7 +580,6 @@ static bool initTargetOptions(DiagnosticsEngine &Diags,
   Options.ValueTrackingVariableLocations =
       CodeGenOpts.ValueTrackingVariableLocations;
   Options.XRayOmitFunctionIndex = CodeGenOpts.XRayOmitFunctionIndex;
-
   Options.MCOptions.SplitDwarfFile = CodeGenOpts.SplitDwarfFile;
   Options.MCOptions.MCRelaxAll = CodeGenOpts.RelaxAll;
   Options.MCOptions.MCSaveTempLabels = CodeGenOpts.SaveTempLabels;

--- a/clang/lib/Driver/ToolChains/Arch/Mips.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Mips.cpp
@@ -292,6 +292,14 @@ void mips::getMIPSTargetFeatures(const Driver &D, const llvm::Triple &Triple,
       Features.push_back("-xgot");
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_mjump_table_opt,
+                               options::OPT_mno_jump_table_opt)) {
+    if (A->getOption().matches(options::OPT_mno_jump_table_opt))
+      Features.push_back("+disable-jump-table-opt");
+    else
+      Features.push_back("-disable-jump-table-opt");
+  }
+
   mips::FloatABI FloatABI = mips::getMipsFloatABI(D, Args, Triple);
   if (FloatABI == mips::FloatABI::Soft) {
     // FIXME: Note, this is a hack. We need to pass the selected float

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1921,7 +1921,6 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
             << "-fdiagnostics-hotness-threshold=";
     }
   }
-
   // If the user requested to use a sample profile for PGO, then the
   // backend will need to track source location information so the profile
   // can be incorporated into the IR.

--- a/llvm/include/llvm/CodeGen/CommandFlags.h
+++ b/llvm/include/llvm/CodeGen/CommandFlags.h
@@ -138,8 +138,8 @@ bool getXRayOmitFunctionIndex();
 
 bool getDebugStrictDwarf();
 
-/// Create this object with static storage to register codegen-related command
-/// line options.
+/// Create this object with static storage to register codegen-related
+/// command line options.
 struct RegisterCodeGenFlags {
   RegisterCodeGenFlags();
 };

--- a/llvm/lib/Target/Mips/CMakeLists.txt
+++ b/llvm/lib/Target/Mips/CMakeLists.txt
@@ -59,6 +59,7 @@ add_llvm_target(MipsCodeGen
   MipsTargetMachine.cpp
   MipsTargetObjectFile.cpp
   MicroMipsSizeReduction.cpp
+  NanoMipsCompressJumpTables.cpp
   NanoMipsLoadStoreOptimizer.cpp
   NanoMipsMoveOptimizer.cpp
   NanoMipsRegisterReAllocation.cpp

--- a/llvm/lib/Target/Mips/Mips.h
+++ b/llvm/lib/Target/Mips/Mips.h
@@ -38,6 +38,7 @@ namespace llvm {
   FunctionPass *createMicroMipsSizeReducePass();
   FunctionPass *createMipsExpandPseudoPass();
   FunctionPass *createMipsPreLegalizeCombiner();
+  FunctionPass *createNanoMipsCompressJumpTablesPass();
   FunctionPass *createNanoMipsLoadStoreOptimizerPass();
   FunctionPass *createNanoMipsMoveOptimizerPass();
   FunctionPass *createNanoMipsRegisterReAllocationPass();

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -212,6 +212,9 @@ def FeatureLongCalls : SubtargetFeature<"long-calls", "UseLongCalls", "true",
 def FeatureXGOT
     : SubtargetFeature<"xgot", "UseXGOT", "true", "Assume 32-bit GOT">;
 
+def FeatureUseAbsoluteJumpTables
+    : SubtargetFeature<"disable-jump-table-opt", "UseAbsoluteJumpTables", "true", "Disable jump table optimization, use absolute jump tables instead">;
+
 def FeatureUseIndirectJumpsHazard : SubtargetFeature<"use-indirect-jump-hazard",
                                                     "UseIndirectJumpsHazard",
                                                     "true", "Use indirect jump"

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
 #include <cassert>
 #include <cstdint>
 #include <map>
@@ -72,7 +73,7 @@ using namespace llvm;
 extern cl::opt<bool> EmitJalrReloc;
 
 void MipsAsmPrinter::emitJumpTableInfo() {
-  if (!Subtarget->hasNanoMips()) {
+  if (!Subtarget->hasNanoMips() || Subtarget->useAbsoluteJumpTables() ) {
     AsmPrinter::emitJumpTableInfo();
     return;
   }

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -71,6 +71,56 @@ using namespace llvm;
 
 extern cl::opt<bool> EmitJalrReloc;
 
+void MipsAsmPrinter::emitJumpTableInfo() {
+  if (!Subtarget->hasNanoMips()) {
+    AsmPrinter::emitJumpTableInfo();
+    return;
+  }
+
+  const MachineJumpTableInfo *MJTI = MF->getJumpTableInfo();
+  if (!MJTI)
+    return;
+
+  const std::vector<MachineJumpTableEntry> &JT = MJTI->getJumpTables();
+  if (JT.empty())
+    return;
+
+  const Function &F = MF->getFunction();
+  const TargetLoweringObjectFile &TLOF = getObjFileLowering();
+
+  MCSection *ReadOnlySection = TLOF.getSectionForJumpTable(F, TM);
+  OutStreamer->SwitchSection(ReadOnlySection);
+
+  auto MFI = MF->getInfo<MipsFunctionInfo>();
+  for (unsigned JTI = 0, e = JT.size(); JTI != e; ++JTI) {
+    const std::vector<MachineBasicBlock *> &JTBBs = JT[JTI].MBBs;
+
+    // If this jump table was deleted, ignore it.
+    if (JTBBs.empty())
+      continue;
+
+    unsigned EntrySize = MFI->getJumpTableEntrySize(JTI);
+    bool Signed = MFI->getJumpTableIsSigned(JTI);
+    emitJumpTableDir(*OutStreamer, EntrySize, JTBBs.size(), Signed);
+    emitAlignment(Align(EntrySize));
+    OutStreamer->emitLabel(GetJTISymbol(JTI));
+
+    MCSymbol *DiffLbl = MFI->getJumpTableSymbol(JTI);
+    for (auto *JTBB : JTBBs) {
+      const MCExpr *Value =
+          MCSymbolRefExpr::create(JTBB->getSymbol(), OutContext);
+      const MCExpr *DiffExpr = MCSymbolRefExpr::create(DiffLbl, OutContext);
+
+      // Each entry is:
+      //     .byte/.hword/...   (LBB - LBR) >> 1
+      Value = MCBinaryExpr::createSub(Value, DiffExpr, OutContext);
+      Value = MCBinaryExpr::createLShr(
+          Value, MCConstantExpr::create(1, OutContext), OutContext);
+      OutStreamer->emitValue(Value, EntrySize);
+    }
+  }
+}
+
 MipsTargetStreamer &MipsAsmPrinter::getTargetStreamer() const {
   return static_cast<MipsTargetStreamer &>(*OutStreamer->getTargetStreamer());
 }
@@ -79,6 +129,7 @@ bool MipsAsmPrinter::runOnMachineFunction(MachineFunction &MF) {
   Subtarget = &MF.getSubtarget<MipsSubtarget>();
 
   MipsFI = MF.getInfo<MipsFunctionInfo>();
+  MFI = MF.getInfo<MipsFunctionInfo>();
   if (Subtarget->inMips16Mode())
     for (std::map<
              const char *,
@@ -151,6 +202,79 @@ void MipsAsmPrinter::emitPseudoIndirectBranch(MCStreamer &OutStreamer,
   TmpInst0.addOperand(MCOp);
 
   EmitToStreamer(OutStreamer, TmpInst0);
+}
+
+void MipsAsmPrinter::emitJumpTableDest(MCStreamer &OutStreamer,
+                                       const MachineInstr *MI) {
+  Register DestReg = MI->getOperand(0).getReg();
+  Register TableReg = MI->getOperand(1).getReg();
+  Register EntryReg = MI->getOperand(2).getReg();
+  int JTIdx = MI->getOperand(3).getIndex();
+  unsigned Size = MFI->getJumpTableEntrySize(JTIdx);
+  unsigned Signed = MFI->getJumpTableIsSigned(JTIdx) ? 1 : 0;
+
+  // Mark each load instruction that loads from the table with a
+  // R_NANOMIPS_JUMPTABLE_LOAD relocation, referring to the start of the table.
+  MCSymbol *JTLabel = MF->getJTISymbol(JTIdx, OutContext);
+  MCSymbol *OffsetLabel = OutContext.createTempSymbol();
+  const MCExpr *OffsetExpr = MCSymbolRefExpr::create(OffsetLabel, OutContext);
+  const MCExpr *JTLabelExpr = MCSymbolRefExpr::create(JTLabel, OutContext);
+  OutStreamer.emitRelocDirective(*OffsetExpr, "R_NANOMIPS_JUMPTABLE_LOAD",
+                                 JTLabelExpr, SMLoc(),
+                                 *TM.getMCSubtargetInfo());
+  OutStreamer.emitLabel(OffsetLabel);
+
+  MCInst LoadI;
+  // Choose appropriate load instruction based on the entry size and signess.
+  switch (Size) {
+  case 1:
+    LoadI.setOpcode(Signed ? Mips::LBX_NM : Mips::LBUX_NM);
+    break;
+  case 2:
+    LoadI.setOpcode(Signed ? Mips::LHXS_NM : Mips::LHUXS_NM);
+    break;
+  case 4:
+    LoadI.setOpcode(Mips::LWXS_NM);
+    break;
+
+  default:
+    llvm_unreachable("unallowed jump table entry size");
+    break;
+  }
+
+  LoadI.addOperand(MCOperand::createReg(DestReg));
+  LoadI.addOperand(MCOperand::createReg(TableReg));
+  LoadI.addOperand(MCOperand::createReg(EntryReg));
+  EmitToStreamer(OutStreamer, LoadI);
+}
+
+// Each table starts with the following directive:
+//
+// .jumptable esize, nsize [, unsigned]
+//
+// esize: size of each element 8/16/32
+// nsize: number of elements in table
+// unsigned: optional token, assume signed if not specified.
+void MipsAsmPrinter::emitJumpTableDir(MCStreamer &OutStreamer,
+                                      unsigned int EntrySize,
+                                      unsigned int EntryNum, bool Signed) {
+  auto JTDir = Twine(".jumptable ");
+  OutStreamer.emitRawText(JTDir.concat(std::to_string(EntrySize))
+                              .concat(",")
+                              .concat(std::to_string(EntryNum))
+                              .concat(Signed ? "" : ",1"));
+}
+
+void MipsAsmPrinter::emitBrsc(MCStreamer &OutStreamer, const MachineInstr *MI) {
+  int JTIdx = MI->getOperand(1).getIndex();
+  int Size = MFI->getJumpTableEntrySize(JTIdx);
+  bool Signed = MFI->getJumpTableIsSigned(JTIdx);
+  MCSymbol *BRSCLabel = OutContext.createTempSymbol("BRSC");
+  MCInst TmpInst0;
+  MCInstLowering.Lower(MI, TmpInst0);
+  EmitToStreamer(OutStreamer, TmpInst0);
+  OutStreamer.emitLabel(BRSCLabel);
+  MFI->setJumpTableEntryInfo(JTIdx, Size, BRSCLabel, Signed);
 }
 
 // If there is an MO_JALR operand, insert:
@@ -275,6 +399,16 @@ void MipsAsmPrinter::emitInstruction(const MachineInstr *MI) {
       continue;
     }
 
+    if (Subtarget->hasNanoMips() &&
+        (I->getOpcode() == Mips::LoadJumpTableOffset)) {
+      emitJumpTableDest(*OutStreamer, &*I);
+      continue;
+    }
+
+    if (Subtarget->hasNanoMips() && I->getOpcode() == Mips::BRSC_NM) {
+      emitBrsc(*OutStreamer, &*I);
+      continue;
+    }
     // The inMips16Mode() test is not permanent.
     // Some instructions are marked as pseudo right now which
     // would make the test fail for the wrong reason but

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.h
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.h
@@ -78,6 +78,15 @@ private:
   void emitPseudoIndirectBranch(MCStreamer &OutStreamer,
                                 const MachineInstr *MI);
 
+  void emitJumpTableDest(MCStreamer &OutStreamer, const MachineInstr *MI);
+
+  // Emit brsc instruction followed by a label that will be used while creating
+  // offset expressions in jump table entries.
+  void emitBrsc(MCStreamer &OutStreamer, const MachineInstr *MI);
+
+  void emitJumpTableDir(MCStreamer &OutStreamer, unsigned int EntrySize,
+                        unsigned int EntryNum, bool Signed);
+
   // lowerOperand - Convert a MachineOperand into the equivalent MCOperand.
   bool lowerOperand(const MachineOperand &MO, MCOperand &MCOp);
 
@@ -116,6 +125,7 @@ private:
 public:
   const MipsSubtarget *Subtarget;
   const MipsFunctionInfo *MipsFI;
+  MipsFunctionInfo *MFI;
   MipsMCInstLower MCInstLowering;
 
   explicit MipsAsmPrinter(TargetMachine &TM,
@@ -158,6 +168,7 @@ public:
   void emitEndOfAsmFile(Module &M) override;
   void PrintDebugValueComment(const MachineInstr *MI, raw_ostream &OS);
   void emitDebugValue(const MCExpr *Value, unsigned Size) const override;
+  void emitJumpTableInfo() override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -299,6 +299,7 @@ const char *MipsTargetLowering::getTargetNodeName(unsigned Opcode) const {
   case MipsISD::PCKEV:             return "MipsISD::PCKEV";
   case MipsISD::PCKOD:             return "MipsISD::PCKOD";
   case MipsISD::INSVE:             return "MipsISD::INSVE";
+  case MipsISD::BR_JT:             return "MipsISD::BR_JT";
   }
   return nullptr;
 }
@@ -349,7 +350,10 @@ MipsTargetLowering::MipsTargetLowering(const MipsTargetMachine &TM,
   AddPromotedToType(ISD::SETCC, MVT::i1, MVT::i32);
 
   // Mips Custom Operations
-  setOperationAction(ISD::BR_JT,              MVT::Other, Expand);
+  if (Subtarget.hasNanoMips())
+    setOperationAction(ISD::BR_JT, MVT::Other, Custom);
+  else
+    setOperationAction(ISD::BR_JT, MVT::Other, Expand);
   setOperationAction(ISD::GlobalAddress,      MVT::i32,   Custom);
   setOperationAction(ISD::BlockAddress,       MVT::i32,   Custom);
   setOperationAction(ISD::GlobalTLSAddress,   MVT::i32,   Custom);
@@ -1507,6 +1511,7 @@ LowerOperation(SDValue Op, SelectionDAG &DAG) const
   case ISD::GlobalAddress:      return lowerGlobalAddress(Op, DAG);
   case ISD::BlockAddress:       return lowerBlockAddress(Op, DAG);
   case ISD::GlobalTLSAddress:   return lowerGlobalTLSAddress(Op, DAG);
+  case ISD::BR_JT:              return lowerBR_JT(Op, DAG);
   case ISD::JumpTable:          return lowerJumpTable(Op, DAG);
   case ISD::SELECT:             return lowerSELECT(Op, DAG);
   case ISD::SETCC:              return lowerSETCC(Op, DAG);
@@ -2526,6 +2531,25 @@ lowerGlobalTLSAddress(SDValue Op, SelectionDAG &DAG) const
   SDValue ThreadPointer = DAG.getNode(MipsISD::ThreadPointer, DL, PtrVT);
   return DAG.getNode(ISD::ADD, DL, PtrVT, ThreadPointer, Offset);
 }
+
+SDValue MipsTargetLowering::
+lowerBR_JT(SDValue Op, SelectionDAG &DAG) const {
+  SDLoc DL(Op);
+  SDValue Chain = Op.getOperand(0);
+  SDValue JT = Op.getOperand(1);
+  SDValue Entry = Op.getOperand(2);
+
+  int JTI = cast<JumpTableSDNode>(JT.getNode())->getIndex();
+  auto *MFI = DAG.getMachineFunction().getInfo<MipsFunctionInfo>();
+  MFI->setJumpTableEntryInfo(JTI, 1, nullptr);
+
+  SDValue TJT = DAG.getTargetJumpTable(JTI, MVT::i32);
+  SDNode *Dest =
+      DAG.getMachineNode(Mips::LoadJumpTableOffset, DL, MVT::i32, JT, Entry, TJT);
+  return DAG.getNode(MipsISD::BR_JT, DL, MVT::Other, Chain, SDValue(Dest, 0),
+                     TJT);
+}
+
 
 SDValue MipsTargetLowering::
 lowerJumpTable(SDValue Op, SelectionDAG &DAG) const

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -350,7 +350,7 @@ MipsTargetLowering::MipsTargetLowering(const MipsTargetMachine &TM,
   AddPromotedToType(ISD::SETCC, MVT::i1, MVT::i32);
 
   // Mips Custom Operations
-  if (Subtarget.hasNanoMips())
+  if (Subtarget.hasNanoMips() && !STI.useAbsoluteJumpTables())
     setOperationAction(ISD::BR_JT, MVT::Other, Custom);
   else
     setOperationAction(ISD::BR_JT, MVT::Other, Expand);

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -2541,7 +2541,7 @@ lowerBR_JT(SDValue Op, SelectionDAG &DAG) const {
 
   int JTI = cast<JumpTableSDNode>(JT.getNode())->getIndex();
   auto *MFI = DAG.getMachineFunction().getInfo<MipsFunctionInfo>();
-  MFI->setJumpTableEntryInfo(JTI, 1, nullptr);
+  MFI->setJumpTableEntryInfo(JTI, 4, nullptr);
 
   SDValue TJT = DAG.getTargetJumpTable(JTI, MVT::i32);
   SDNode *Dest =

--- a/llvm/lib/Target/Mips/MipsISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsISelLowering.h
@@ -258,7 +258,10 @@ class TargetRegisterClass;
       UALW,
       UALH,
       UASW,
-      UASH
+      UASH,
+
+      // nanoMIPS br_jt.
+      BR_JT
     };
 
   } // ene namespace MipsISD
@@ -548,6 +551,7 @@ class TargetRegisterClass;
     SDValue lowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerBlockAddress(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerGlobalTLSAddress(SDValue Op, SelectionDAG &DAG) const;
+    SDValue lowerBR_JT(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerJumpTable(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerSELECT(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerSETCC(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/Mips/MipsMachineFunction.h
+++ b/llvm/lib/Target/Mips/MipsMachineFunction.h
@@ -87,6 +87,28 @@ public:
   std::map<const char *, const Mips16HardFloatInfo::FuncSignature *>
   StubsNeeded;
 
+  unsigned getJumpTableEntrySize(int Idx) const {
+    return JumpTableEntryInfo[Idx]->Size;
+  }
+  MCSymbol *getJumpTableSymbol(int Idx) const {
+    return JumpTableEntryInfo[Idx]->Symbol;
+  }
+  bool getJumpTableIsSigned(int Idx) const {
+    return JumpTableEntryInfo[Idx]->Signed;
+  }
+  void setJumpTableEntryInfo(int Idx, unsigned Size, MCSymbol *Sym,
+                             bool Sign = true) {
+    if ((unsigned)Idx >= JumpTableEntryInfo.size())
+      JumpTableEntryInfo.resize(Idx + 1);
+    if (!JumpTableEntryInfo[Idx])
+      JumpTableEntryInfo[Idx] = new NanoMipsJumpTableInfo(Size, Sym, Sign);
+    else {
+      JumpTableEntryInfo[Idx]->Size = Size;
+      JumpTableEntryInfo[Idx]->Symbol = Sym;
+      JumpTableEntryInfo[Idx]->Signed = Sign;
+    }
+  }
+
 private:
   virtual void anchor();
 
@@ -135,6 +157,17 @@ private:
   /// FrameIndex for start of varargs area for arguments passed on the
   /// stack.
   int VarArgsStackIndex = 0;
+
+  /// Info about entry size, signess and Jump Table symbol.
+  struct NanoMipsJumpTableInfo {
+    MCSymbol *Symbol;
+    unsigned Size;
+    bool Signed;
+    NanoMipsJumpTableInfo(unsigned Size, MCSymbol *Sym, bool Sign)
+        : Size(Size), Symbol(Sym), Signed(Sign) {}
+  };
+
+  SmallVector<NanoMipsJumpTableInfo *, 2> JumpTableEntryInfo;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/Mips/MipsSubtarget.h
+++ b/llvm/lib/Target/Mips/MipsSubtarget.h
@@ -199,6 +199,9 @@ class MipsSubtarget : public MipsGenSubtargetInfo {
   // Assume 32-bit GOT.
   bool UseXGOT = false;
 
+  
+  bool UseAbsoluteJumpTables;
+
   // Use unaliged loads and stores (nanoMIPS only).
   bool UseUnalignedLoadStore = false;
 
@@ -341,6 +344,10 @@ public:
   bool useLongCalls() const { return UseLongCalls; }
 
   bool useXGOT() const { return UseXGOT; }
+
+  bool useAbsoluteJumpTables() const {
+    return UseAbsoluteJumpTables && hasNanoMips();
+  }
 
   bool useUnalignedLoadStore() const { return UseUnalignedLoadStore; };
 

--- a/llvm/lib/Target/Mips/MipsTargetMachine.cpp
+++ b/llvm/lib/Target/Mips/MipsTargetMachine.cpp
@@ -333,6 +333,8 @@ MipsTargetMachine::getTargetTransformInfo(const Function &F) {
 // Implemented by targets that want to run passes immediately before
 // machine code is emitted.
 void MipsPassConfig::addPreEmitPass() {
+  if (getMipsSubtarget().hasNanoMips())
+    addPass(createNanoMipsCompressJumpTablesPass());
   // Expand pseudo instructions that are sensitive to register allocation.
   addPass(createMipsExpandPseudoPass());
 

--- a/llvm/lib/Target/Mips/NanoMipsCompressJumpTables.cpp
+++ b/llvm/lib/Target/Mips/NanoMipsCompressJumpTables.cpp
@@ -1,0 +1,153 @@
+//===- NanoMipsCompressJumpTables.cpp - nanoMIPS compress JTs  --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file This file contains a pass that compresses Jump Table entries, whenever
+/// possible. Jump table entries used to be fixed size(4B). They used to
+/// represent absolute addresses. We want to compress those entries by filling
+/// them with specific offsets. Having offsets instead of absolute addresses
+/// saves at least 2B per entry. This pass checks if one or two bytes are
+/// sufficient for the offset value.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Mips.h"
+#include "MipsMachineFunction.h"
+#include "MipsSubtarget.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineJumpTableInfo.h"
+
+#include <cmath>
+
+using namespace llvm;
+
+#define NM_COMPRESS_JUMP_TABLES_OPT_NAME                                       \
+  "nanoMIPS compress jump tables optimization pass"
+
+namespace {
+struct NMCompressJumpTables : public MachineFunctionPass {
+  static char ID;
+  const MipsSubtarget *STI;
+  const TargetInstrInfo *TII;
+  MachineFunction *MF;
+  SmallVector<int, 8> BlockInfo;
+  SmallVector<int, 8> BrOffsets;
+
+  int computeBlockSize(MachineBasicBlock &MBB);
+  void scanFunction();
+  bool compressJumpTable(MachineInstr &MI, int Offset);
+
+  NMCompressJumpTables() : MachineFunctionPass(ID) {}
+  StringRef getPassName() const override {
+    return NM_COMPRESS_JUMP_TABLES_OPT_NAME;
+  }
+  bool runOnMachineFunction(MachineFunction &Fn) override;
+};
+} // namespace
+
+char NMCompressJumpTables::ID = 0;
+
+// TODO: Currently, there is no existing LLVM interface which we can use to tell the
+// maximum potential size of a MachineInstr. Once we have it, this should be
+// enhanced.
+int NMCompressJumpTables::computeBlockSize(MachineBasicBlock &MBB) {
+  int Size = 0;
+  for (const MachineInstr &MI : MBB)
+    Size += TII->getInstSizeInBytes(MI);
+  return Size;
+}
+
+void NMCompressJumpTables::scanFunction() {
+  BlockInfo.clear();
+  BlockInfo.resize(MF->getNumBlockIDs());
+  BrOffsets.clear();
+  bool findBR = MF->getJumpTableInfo() &&
+                !MF->getJumpTableInfo()->getJumpTables().empty();
+  if (findBR)
+    BrOffsets.resize(MF->getJumpTableInfo()->getJumpTables().size());
+  int Offset = 0;
+  for (MachineBasicBlock &MBB : *MF) {
+    BlockInfo[MBB.getNumber()] = Offset;
+    Offset += computeBlockSize(MBB);
+    if (findBR)
+      for (auto &MI : MBB) {
+        if (MI.getOpcode() == Mips::BRSC_NM) {
+          int JTIdx = MI.getOperand(1).getIndex();
+          BrOffsets[JTIdx] = Offset;
+          break;
+        }
+      }
+  }
+}
+
+bool NMCompressJumpTables::compressJumpTable(MachineInstr &MI, int Offset) {
+  if (MI.getOpcode() != Mips::LoadJumpTableOffset)
+    return false;
+
+  int JTIdx = MI.getOperand(3).getIndex();
+  auto &JTInfo = *MF->getJumpTableInfo();
+  const MachineJumpTableEntry &JT = JTInfo.getJumpTables()[JTIdx];
+
+  // The jump-table might have been optimized away.
+  if (JT.MBBs.empty())
+    return false;
+
+  int MaxOffset = std::numeric_limits<int>::min(),
+      MinOffset = std::numeric_limits<int>::max();
+  int BrOffset = BrOffsets[JTIdx];
+
+  bool Signed = false;
+  for (auto Block : JT.MBBs) {
+    int BlockOffset = BlockInfo[Block->getNumber()];
+    MaxOffset = std::max(MaxOffset, BlockOffset - BrOffset);
+    MinOffset = std::min(MinOffset, BlockOffset - BrOffset);
+  }
+  if (MinOffset < 0)
+    Signed = true;
+
+  if (std::max(std::abs(MinOffset), MaxOffset) == MinOffset)
+    MaxOffset = MinOffset;
+
+  auto MFI = MF->getInfo<MipsFunctionInfo>();
+  MCSymbol *JTS = MFI->getJumpTableSymbol(JTIdx);
+
+  bool EntrySize1 =
+      (Signed && isInt<8>(MaxOffset)) || (!Signed && isUInt<8>(MaxOffset));
+  bool EntrySize2 =
+      (Signed && isInt<16>(MaxOffset)) || (!Signed && isUInt<16>(MaxOffset));
+  int EntrySize = EntrySize1 ? 1 : (EntrySize2 ? 2 : 4);
+  if (EntrySize1 || EntrySize2)
+    MFI->setJumpTableEntryInfo(JTIdx, EntrySize, JTS, Signed);
+
+  return false;
+}
+
+bool NMCompressJumpTables::runOnMachineFunction(MachineFunction &Fn) {
+  STI = &static_cast<const MipsSubtarget &>(Fn.getSubtarget());
+  TII = STI->getInstrInfo();
+  bool Modified = false;
+  MF = &Fn;
+
+  scanFunction();
+
+  for (MachineBasicBlock &MBB : *MF) {
+    int Offset = BlockInfo[MBB.getNumber()];
+    for (MachineInstr &MI : MBB) {
+      Modified |= compressJumpTable(MI, Offset);
+      Offset += TII->getInstSizeInBytes(MI);
+    }
+  }
+  return Modified;
+}
+
+namespace llvm {
+FunctionPass *createNanoMipsCompressJumpTablesPass() {
+  return new NMCompressJumpTables();
+}
+} // namespace llvm

--- a/llvm/lib/Target/Mips/NanoMipsInstrInfo.td
+++ b/llvm/lib/Target/Mips/NanoMipsInstrInfo.td
@@ -21,6 +21,10 @@ def NMUnalignedLH : SDNode<"MipsISD::UALH", SDTMipsLoadLR, [SDNPHasChain, SDNPMa
 def NMUnalignedSW : SDNode<"MipsISD::UASW", SDTStore, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 def NMUnalignedSH : SDNode<"MipsISD::UASH", SDTStore, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 
+def SDT_NMbr_jt : SDTypeProfile<0, 2, []>;
+
+def NMbr_jt : SDNode<"MipsISD::BR_JT", SDT_NMbr_jt, [SDNPHasChain]>;
+
 //===----------------------------------------------------------------------===//
 // nanoMIPS Operand, Complex Patterns and Transformations Definitions.
 //===----------------------------------------------------------------------===//
@@ -393,6 +397,13 @@ def OR16_NM  : ArithLogicR16<"or16", GPR3Opnd>;
 
 def JRC_NM : IndirectBranchNM<"jrc", GPR32NMOpnd>;
 
+let isCodeGenOnly = 1, hasNoSchedulingInfo = 1,
+    hasDelaySlot = 0, isBranch = 1,
+   isTerminator = 1,
+   hasDelaySlot = 0,
+   isCTI = 1 in
+def BRSC_NM : InstNM<(outs), (ins GPR32NMOpnd:$rs, GPR32NMOpnd: $jti), "brsc\t$rs", [(NMbr_jt GPR32NMOpnd:$rs, GPR32NMOpnd: $jti)]>, InstSize32;
+
 def BALC_NM : CallNM<"balc", MipsJmpLink, tglobaladdr>, InstSize32;
 def MOVEBALC_NM : MoveBalcBase;
 
@@ -427,6 +438,9 @@ def PseudoReturnNM : PseudoInstNM<(outs), (ins GPR32NMOpnd:$rs), []> {
   let hasExtraSrcRegAllocReq = 1;
   bit isCTI = 1;
 }
+
+let isCodeGenOnly = 1, hasNoSchedulingInfo = 1, hasDelaySlot = 0 in
+def LoadJumpTableOffset : PseudoInstNM<(outs GPR32NMOpnd:$rd), (ins GPR32NMOpnd:$table, GPR32NMOpnd:$entry, GPR32NMOpnd:$jti), []>;
 
 // Indirect branch is matched as PseudoIndirectBranchNM and expanded to JRC_NM.
 def PseudoIndirectBranchNM :


### PR DESCRIPTION
Currently, LLVM for nanomips uses jumptables with 4-byte entries that are absolute addresses of target labels. This patchset resolves it in the following way. First, we're emitting 1-byte entries unconditionally. Then, we're introducing a new MIR pass that checks whether it is okay to compress jump table entries. The third patch introduces the mno-jump-table-opt option that enables reverting to absolute jump tables.