### PR TITLE
NanoMips: OR combine optimization

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -1047,7 +1047,7 @@ static SDValue attemptOrToIns(SDValue &And, SDValue &Right, SDNode *N,
     return SDValue();
   unsigned Mask0 = ~CN->getZExtValue();
 
-  KnownBits KnownMaskBits = DAG.computeKnownBits(And.getOperand(1));
+  KnownBits KnownMaskBits = DAG.computeKnownBits(SDValue(CN, 0));
   APInt maxValue = KnownMaskBits.getMaxValue();
   unsigned int MaxNumOfActiveBitsInMask = maxValue.getActiveBits();
 
@@ -1157,7 +1157,7 @@ static SDValue attemptOrToIns(SDValue &And, SDValue &Right, SDNode *N,
       // then we will allow replacement with the INS instruction
       // because we are sure that we have only leading zeros
       KnownBits Known = DAG.computeKnownBits(Right.getOperand(0));
-      if (Known.countMaxPopulation() > SMSize0)
+      if (Known.getMaxValue().getActiveBits() > SMSize0)
         return SDValue();
     }
 

--- a/llvm/test/CodeGen/Mips/nanomips/ins.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/ins.ll
@@ -60,3 +60,43 @@ define i32 @ins6(i32 %a, i32 %b) {
   %or = or i32 %and1, %shift
   ret i32 %or
 }
+
+define i32 @ins7(i32 %a, i8 %b) {
+  ; CHECK: ins $a0, $a1, 16, 8
+  %and1 = and i32 %a, 4278255615 ; 0xff00ffff
+  %conv = zext i8 %b to i32
+  %shift = shl i32 %conv, 16
+  %or = or i32 %and1, %shift
+  ret i32 %or
+}
+
+define i32 @ins8(i32 %a, i16 %b) {
+  ; CHECK: ins $a0, $a1, 8, 16
+  %and1 = and i32 %a, 4278190335 ; 0xff0000ff
+  %conv = zext i16 %b to i32
+  %shift = shl i32 %conv, 8
+  %or = or i32 %and1, %shift
+  ret i32 %or
+}
+
+define i32 @ins9(i32 %a, i8* %b) {
+  ; CHECK: ins $a0, $a1, 16, 8
+  %val = load i8, i8* %b
+  %and1 = and i32 %a, 4278255615 ; 0xff00ffff
+  %conv = zext i8 %val to i32
+  %shift = shl i32 %conv, 16
+  %or = or i32 %and1, %shift
+  ret i32 %or
+}
+
+define i32 @ins10(i32 %a, i16* %b) {
+  ; CHECK: ins $a0, $a1, 8, 16
+  %val = load i16, i16* %b
+  %and1 = and i32 %a, 4278190335 ; 0xff0000ff
+  %conv = zext i16 %val to i32
+  %shift = shl i32 %conv, 8
+  %or = or i32 %and1, %shift
+  ret i32 %or
+}
+
+


### PR DESCRIPTION
Combine OR into INS when there is no masking for
the second register but it holds zero extended
value whose original width is less than equal to
the number of bits from the first register set
to zero.

This resolves the following issue:

> Bitfield insert a value that can fit into value such as 0xff0004 (do not assume it is exactly the same width).