### PR TITLE
Improving update_llc_test_checks.py script

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/mips_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/mips_generated_funcs.ll.generated.expected
@@ -86,14 +86,14 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    j $BB0_5
 ; CHECK-NEXT:    sw $1, 8($fp)
 ; CHECK-NEXT:  $BB0_3:
-; CHECK-NEXT:    balc OUTLINED_FUNCTION_6342aa443a2a9a5887d1350bbc1e09528fec5a00eb7c233d57781b9d3c73b1a4
+; CHECK-NEXT:    balc OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    lw $1, 16($fp)
 ; CHECK-NEXT:    bnez $1, $BB0_2
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:  $BB0_4:
-; CHECK-NEXT:    balc OUTLINED_FUNCTION_6342aa443a2a9a5887d1350bbc1e09528fec5a00eb7c233d57781b9d3c73b1a4
+; CHECK-NEXT:    balc OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  $BB0_5:
-; CHECK-NEXT:    bc OUTLINED_FUNCTION_c71f1bd49b1f15e9cb47cb98c9592cfb18460320a4024fa283e78fa0f1fb5852
+; CHECK-NEXT:    bc OUTLINED_FUNCTION[[SUFFIX1:.*]]
 ;
 ; CHECK-LABEL: main:
 ; CHECK:       # %bb.0:
@@ -122,9 +122,9 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    sw $2, 16($fp)
 ; CHECK-NEXT:    sw $3, 8($fp)
 ; CHECK-NEXT:    sw $4, 4($fp)
-; CHECK-NEXT:    bc OUTLINED_FUNCTION_c71f1bd49b1f15e9cb47cb98c9592cfb18460320a4024fa283e78fa0f1fb5852
+; CHECK-NEXT:    bc OUTLINED_FUNCTION[[SUFFIX1]]
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_6342aa443a2a9a5887d1350bbc1e09528fec5a00eb7c233d57781b9d3c73b1a4:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX0]]:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addiu $1, $zero, 2
 ; CHECK-NEXT:    sw $1, 12($fp)
@@ -136,7 +136,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    sw $1, 4($fp)
 ; CHECK-NEXT:    jrc $ra
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_c71f1bd49b1f15e9cb47cb98c9592cfb18460320a4024fa283e78fa0f1fb5852:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX1]]:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addiu $2, $zero, 0
 ; CHECK-NEXT:    move $sp, $fp

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/mips_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/mips_generated_funcs.ll.nogenerated.expected
@@ -27,14 +27,14 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    j $BB0_5
 ; CHECK-NEXT:    sw $1, 8($fp)
 ; CHECK-NEXT:  $BB0_3:
-; CHECK-NEXT:    balc OUTLINED_FUNCTION_6342aa443a2a9a5887d1350bbc1e09528fec5a00eb7c233d57781b9d3c73b1a4
+; CHECK-NEXT:    balc OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    lw $1, 16($fp)
 ; CHECK-NEXT:    bnez $1, $BB0_2
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:  $BB0_4:
-; CHECK-NEXT:    balc OUTLINED_FUNCTION_6342aa443a2a9a5887d1350bbc1e09528fec5a00eb7c233d57781b9d3c73b1a4
+; CHECK-NEXT:    balc OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  $BB0_5:
-; CHECK-NEXT:    bc OUTLINED_FUNCTION_c71f1bd49b1f15e9cb47cb98c9592cfb18460320a4024fa283e78fa0f1fb5852
+; CHECK-NEXT:    bc OUTLINED_FUNCTION[[SUFFIX1:.*]]
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4
@@ -99,7 +99,7 @@ define dso_local i32 @main() #0 {
 ; CHECK-NEXT:    sw $2, 16($fp)
 ; CHECK-NEXT:    sw $3, 8($fp)
 ; CHECK-NEXT:    sw $4, 4($fp)
-; CHECK-NEXT:    bc OUTLINED_FUNCTION_c71f1bd49b1f15e9cb47cb98c9592cfb18460320a4024fa283e78fa0f1fb5852
+; CHECK-NEXT:    bc OUTLINED_FUNCTION[[SUFFIX1]]
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4

--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -411,9 +411,6 @@ def get_run_handler(triple):
       handler = s
       best_prefix = prefix
 
-  global target
-  target = best_prefix
-
   if handler is None:
     raise KeyError('Triple %r is not supported' % (triple))
 

--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -411,6 +411,9 @@ def get_run_handler(triple):
       handler = s
       best_prefix = prefix
 
+  global target
+  target = best_prefix
+
   if handler is None:
     raise KeyError('Triple %r is not supported' % (triple))
 

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -19,6 +19,9 @@ else:
 _verbose = False
 _prefix_filecheck_ir_name = ''
 
+from UpdateTestChecks import asm
+outlined_fn_to_filecheck_var = {}
+
 def parse_commandline_args(parser):
   parser.add_argument('--include-generated-funcs', action='store_true',
                       help='Output checks for functions not in source')
@@ -630,6 +633,9 @@ def generalize_check_lines(lines, is_analyze, vars_seen, global_vars_seen):
 
 
 def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, check_label_format, is_asm, is_analyze, global_vars_seen_dict):
+  global outlined_function_counter
+  outlined_function_counter = 0
+
   # prefix_exclusions are prefixes we cannot use to print the function because it doesn't exist in run lines that use these prefixes as well.
   prefix_exclusions = set()
   printed_prefixes = []
@@ -685,7 +691,17 @@ def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, 
         output_lines.append(check_label_format % (checkprefix, func_name, ''))
         output_lines.append('%s %s-SAME: %s' % (comment_marker, checkprefix, args_and_sig))
       else:
-        output_lines.append(check_label_format % (checkprefix, func_name, args_and_sig))
+        # If we are on Mips target check if we generate new name for outlined function that
+        # contains FileCheck variable in it and if so, use that name in CHECK-LABEL directive.
+        is_outlined_fn = func_name.find("OUTLINED_FUNCTION")
+        if is_outlined_fn != -1 and asm.target == "mips":
+          new_func_name = outlined_fn_to_filecheck_var[func_name][1]
+          # FileCheck local variables don't work inside CHECK-LABEL so we will use CHECK
+          # for outlined function names.
+          new_check_format = '{} %s: %s%s:'.format(comment_marker)
+          output_lines.append(new_check_format % (checkprefix, new_func_name, args_and_sig))
+        else:
+          output_lines.append(check_label_format % (checkprefix, func_name, args_and_sig))
       func_body = str(func_dict[checkprefix][func_name]).splitlines()
 
       # For ASM output, just emit the check lines.
@@ -695,7 +711,41 @@ def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, 
           if func_line.strip() == '':
             output_lines.append('%s %s-EMPTY:' % (comment_marker, checkprefix))
           else:
-            output_lines.append('%s %s-NEXT:  %s' % (comment_marker, checkprefix, func_line))
+            # We want to generalize outlined function suffixes for Mips target.
+            # For this purpose we use FileCheck variables and we replace outlined
+            # function names with it as we go through the assembly instructions.
+            outlined_fn_prefix = "OUTLINED_FUNCTION"
+            outlined_fn_prefix_index = func_line.find(outlined_fn_prefix)
+            if outlined_fn_prefix_index != -1 and asm.target == "mips":
+              # Get original outlined function name
+              full_outlined_fn_name = func_line[outlined_fn_prefix_index:].split()[0]
+              new_outlined_fn_name = ''
+              # If we already saw this outlined function get it's new name that contains
+              # FileCheck variable reference.
+              if full_outlined_fn_name in outlined_fn_to_filecheck_var.keys():
+                new_outlined_fn_name = outlined_fn_to_filecheck_var[full_outlined_fn_name][1]
+              else:
+                # If we see this outlined function name for the first time, generate FileCheck variable
+                # with regex expression to capture name suffix and save it in
+                # outlined_fn_to_filecheck_var map.
+                suffix = "[[SUFFIX" + str(outlined_function_counter) + ":.*]]"
+                new_outlined_fn_name = full_outlined_fn_name[:len(outlined_fn_prefix)] + suffix
+
+                suffix_ref = "[[SUFFIX" + str(outlined_function_counter) +"]]"
+                # new_outlined_fn_name_ref is new outlined function name to emit with CHECK-LABEL directive
+                # later, when we encounter appropriate outlined function label.
+                new_outlined_fn_name_ref = full_outlined_fn_name[:len(outlined_fn_prefix)] + suffix_ref
+                outlined_fn_to_filecheck_var[full_outlined_fn_name] = (new_outlined_fn_name, new_outlined_fn_name_ref)
+
+                # Increase the counter to distinguish the following suffixes from the previous ones.
+                outlined_function_counter = outlined_function_counter + 1
+
+              # Update outlined function name inside current line and emit CHECK directive.
+              new_func_line = func_line[:outlined_fn_prefix_index] + new_outlined_fn_name \
+                                + func_line[outlined_fn_prefix_index+len(full_outlined_fn_name):]
+              output_lines.append('%s %s-NEXT:  %s' % (comment_marker, checkprefix, new_func_line))
+            else:
+              output_lines.append('%s %s-NEXT:  %s' % (comment_marker, checkprefix, func_line))
         break
 
       # For IR output, change all defs to FileCheck variables, so we're immune

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -19,7 +19,6 @@ else:
 _verbose = False
 _prefix_filecheck_ir_name = ''
 
-from UpdateTestChecks import asm
 outlined_fn_to_filecheck_var = {}
 
 def parse_commandline_args(parser):
@@ -691,10 +690,10 @@ def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, 
         output_lines.append(check_label_format % (checkprefix, func_name, ''))
         output_lines.append('%s %s-SAME: %s' % (comment_marker, checkprefix, args_and_sig))
       else:
-        # If we are on Mips target check if we generate new name for outlined function that
-        # contains FileCheck variable in it and if so, use that name in CHECK-LABEL directive.
+        # Check if we generated new name for outlined function that contains FileCheck
+        # variable in it and if so, use that name in CHECK directive.
         is_outlined_fn = func_name.find("OUTLINED_FUNCTION")
-        if is_outlined_fn != -1 and asm.target == "mips":
+        if is_outlined_fn != -1:
           new_func_name = outlined_fn_to_filecheck_var[func_name][1]
           # FileCheck local variables don't work inside CHECK-LABEL so we will use CHECK
           # for outlined function names.
@@ -711,12 +710,12 @@ def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, 
           if func_line.strip() == '':
             output_lines.append('%s %s-EMPTY:' % (comment_marker, checkprefix))
           else:
-            # We want to generalize outlined function suffixes for Mips target.
+            # We want to generalize outlined function suffixes.
             # For this purpose we use FileCheck variables and we replace outlined
             # function names with it as we go through the assembly instructions.
             outlined_fn_prefix = "OUTLINED_FUNCTION"
             outlined_fn_prefix_index = func_line.find(outlined_fn_prefix)
-            if outlined_fn_prefix_index != -1 and asm.target == "mips":
+            if outlined_fn_prefix_index != -1:
               # Get original outlined function name
               full_outlined_fn_name = func_line[outlined_fn_prefix_index:].split()[0]
               new_outlined_fn_name = ''


### PR DESCRIPTION
Script that automatically generates CHECK directives has been improved to generate outlined function names with arbitrary suffix for Mips target. This means that, inside ```MachineOutliner``` class, the label names of the outlined functions can change their suffix after the ```OUTLINED_FUNCTION``` part of the label and then the ```CHECK``` directives generated by this script will still be correct. In this way, the script is made more flexible.

This also fixes test ```mips_generated_funcs.test```.
