### PR TITLE
Avoid swm/lwm of volatile accesses.

### DIFF
--- a/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
@@ -429,6 +429,13 @@ unsigned NMLoadStoreOpt::getRegNo(unsigned Reg) {
 
 bool NMLoadStoreOpt::isValidLoadStore(MachineInstr &MI, bool IsLoad) {
   unsigned Opcode = MI.getOpcode();
+
+  // Make sure the instruction doesn't have any atomic, volatile or
+  // otherwise strictly ordered accesses.
+  for (auto &MMO : MI.memoperands())
+    if (MMO->isAtomic() || !MMO->isUnordered())
+      return false;
+
   if (IsLoad) {
     // TODO: Handle unaligned loads and stores.
     if (Opcode == Mips::LW_NM || Opcode == Mips::LWs9_NM) {

--- a/llvm/test/CodeGen/Mips/nanomips/test-volatile-swm.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/test-volatile-swm.ll
@@ -4,7 +4,7 @@ target triple = "nanomips"
 
 %struct.S = type { i32, i32 }
 
-declare dso_local inreg { i32, i32 } @GetStruct(...) local_unnamed_addr 
+declare dso_local inreg { i32, i32 } @GetStruct(...) local_unnamed_addr
 
 define dso_local void @test(%struct.S* %p, i32 signext %i) local_unnamed_addr {
 entry:
@@ -20,5 +20,4 @@ entry:
   store volatile i32 %0, i32* %A26, align 4
   ret void
 }
-; CHECK: astemunhtobeix
 

--- a/llvm/test/CodeGen/Mips/nanomips/test-volatile-swm.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/test-volatile-swm.ll
@@ -1,0 +1,24 @@
+; RUN: llc -march=nanomips  < %s | FileCheck %s
+target datalayout = "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32:64-S128"
+target triple = "nanomips"
+
+%struct.S = type { i32, i32 }
+
+declare dso_local inreg { i32, i32 } @GetStruct(...) local_unnamed_addr 
+
+define dso_local void @test(%struct.S* %p, i32 signext %i) local_unnamed_addr {
+entry:
+; CHECK-NOT: swm
+; CHECK: sw
+; CHECK: sw
+  %call = tail call inreg { i32, i32 } bitcast ({ i32, i32 } (...)* @GetStruct to { i32, i32 } ()*)() 
+  %0 = extractvalue { i32, i32 } %call, 0
+  %1 = extractvalue { i32, i32 } %call, 1
+  %B1 = getelementptr inbounds %struct.S, %struct.S* %p, i32 0, i32 1
+  store volatile i32 %1, i32* %B1, align 4
+  %A26 = bitcast %struct.S* %p to i32*
+  store volatile i32 %0, i32* %A26, align 4
+  ret void
+}
+; CHECK: astemunhtobeix
+


### PR DESCRIPTION
Merging volatile accesses into lwm/swm can change the order of accesses and may have other undesirable effects. Disallow it.