### PR TITLE
Only use LWM/SWM when optimising for size.

### DIFF
--- a/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
@@ -90,7 +90,7 @@ bool NMLoadStoreOpt::runOnMachineFunction(MachineFunction &Fn) {
       Modified |= generateSaveOrRestore(MBB, /*IsRestore=*/false);
       Modified |= generateSaveOrRestore(MBB, /*IsRestore=*/true);
     }
-    if (!DisableNMLoadStoreMultiple) {
+    if (!DisableNMLoadStoreMultiple && Fn.getFunction().hasOptSize()) {
       Modified |= generateLoadStoreMultiple(MBB, /*IsLoad=*/false);
       Modified |= generateLoadStoreMultiple(MBB, /*IsLoad=*/true);
     }


### PR DESCRIPTION
The macro nature of these instructions makes them slower than their
individual instruction equivalents, so only use them when optimising
for size.