### PR TITLE
Fix brsc and suppress warnings

### DIFF
--- a/llvm/lib/Target/Mips/MipsMachineFunction.h
+++ b/llvm/lib/Target/Mips/MipsMachineFunction.h
@@ -101,7 +101,7 @@ public:
     if ((unsigned)Idx >= JumpTableEntryInfo.size())
       JumpTableEntryInfo.resize(Idx + 1);
     if (!JumpTableEntryInfo[Idx])
-      JumpTableEntryInfo[Idx] = new NanoMipsJumpTableInfo(Size, Sym, Sign);
+      JumpTableEntryInfo[Idx] = new NanoMipsJumpTableInfo(Sym, Size, Sign);
     else {
       JumpTableEntryInfo[Idx]->Size = Size;
       JumpTableEntryInfo[Idx]->Symbol = Sym;
@@ -163,8 +163,8 @@ private:
     MCSymbol *Symbol;
     unsigned Size;
     bool Signed;
-    NanoMipsJumpTableInfo(unsigned Size, MCSymbol *Sym, bool Sign)
-        : Size(Size), Symbol(Sym), Signed(Sign) {}
+    NanoMipsJumpTableInfo(MCSymbol *Sym, unsigned Size, bool Sign)
+        : Symbol(Sym), Size(Size), Signed(Sign) {}
   };
 
   SmallVector<NanoMipsJumpTableInfo *, 2> JumpTableEntryInfo;

--- a/llvm/lib/Target/Mips/MipsTargetMachine.h
+++ b/llvm/lib/Target/Mips/MipsTargetMachine.h
@@ -111,7 +111,7 @@ public:
                         Optional<CodeModel::Model> CM, CodeGenOpt::Level OL,
                         bool JIT);
 
-  bool useIPRA() const {
+  bool useIPRA() const override {
     return true;
   }
 };

--- a/llvm/lib/Target/Mips/NanoMipsInstrInfo.td
+++ b/llvm/lib/Target/Mips/NanoMipsInstrInfo.td
@@ -407,6 +407,7 @@ def JRC_NM : IndirectBranchNM<"jrc", GPR32NMOpnd>;
 
 let isCodeGenOnly = 1, hasNoSchedulingInfo = 1,
     hasDelaySlot = 0, isBranch = 1,
+    isBarrier = 1,
    isTerminator = 1,
    hasDelaySlot = 0,
    isCTI = 1 in


### PR DESCRIPTION
Added isBarier flag to definition of BRSC_NM.

Suppressed warnings during build:
 - Reordered NanoMipsJumpTableInfo constructor parameters.
 - Added override identifier to use useIPRA.
