### PR TITLE
Set CFA after adjusting stack pointer in function epilogue

### DIFF
--- a/llvm/lib/Target/Mips/MipsSEFrameLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEFrameLowering.cpp
@@ -749,6 +749,15 @@ void MipsSEFrameLowering::emitEpilogue(MachineFunction &MF,
 
   // Adjust stack.
   TII.adjustStackPtr(SP, StackSize, MBB, MBBI);
+
+  // emit ".cfi_def_cfa_offset StackSize"
+  MCSymbol *FrameLabel = MF.getContext().createTempSymbol();
+  unsigned CFIIndex =
+    MF.addFrameInst(MCCFIInstruction::cfiDefCfaOffset(FrameLabel, 0));
+  BuildMI(MBB, MBBI, DL, TII.get(TargetOpcode::CFI_INSTRUCTION))
+    .addCFIIndex(CFIIndex)
+    .setMIFlags(MachineInstr::FrameSetup);
+
 }
 
 void MipsSEFrameLowering::emitInterruptEpilogueStub(


### PR DESCRIPTION
After the final stack adjustment in the epilogue, the stack pointer points directly at the CFA without any offset. Reflect this in the deug info as single-stepping by instruction will show a difference in frame addresses after adjusting the stack and before returning from the function.