### PR TITLE
Fix failing tests

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -50,7 +50,8 @@ MipsMCAsmInfo::MipsMCAsmInfo(const Triple &TheTriple,
   ExceptionsType = ExceptionHandling::DwarfCFI;
   DwarfRegNumForCFI = true;
   HasMipsExpressions = true;
-  UseIntegratedAssembler = false;
+  if (TheTriple.isNanoMips())
+    UseIntegratedAssembler = false;
   if (ABI.IsP32())
     HasLEB128Directives = false;
 }

--- a/llvm/test/CodeGen/Mips/nanomips/disable_optimizers.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/disable_optimizers.ll
@@ -9,7 +9,7 @@
 ; CHECK-NO-LWM-SWM-LABEL: test4:
 ; CHECK-NO-PCREL-LABEL: test4:
 
-define void @test4(i32 %n, ...) {
+define void @test4(i32 %n, ...) optsize {
 ; CHECK: swm $a1, 4($sp), 7
 ; CHECK-NO-SAVE-RESTORE: swm $a1, 4($sp), 7
 ; CHECK-NO-LWM-SWM-NOT: swm
@@ -26,7 +26,7 @@ define void @test4(i32 %n, ...) {
 ; CHECK-NO-LWM-SWM-LABEL: square:
 ; CHECK-NO-PCREL-LABEL: square:
 
-define void @square(%struct.bar* %ints) {
+define void @square(%struct.bar* %ints) optsize {
 
 ; CHECK: lwm $a1, 0($a0), 2
 ; CHECK-NO-SAVE-RESTORE: lwm $a1, 0($a0), 2
@@ -49,7 +49,7 @@ define void @square(%struct.bar* %ints) {
 ; CHECK-NO-PCREL-LABEL: test:
 
 ; Make sure that SAVE/RESTORE instructions are used for saving and restoring callee-saved registers.
-define void @test() {
+define void @test() optsize {
 ; CHECK: save 32, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
 ; CHECK-NO-SAVE-RESTORE-NOT: save
 ; CHECK-NO-LWM-SWM: save 32, $s0, $s1, $s2, $s3, $s4, $s5, $s6, $s7
@@ -74,7 +74,7 @@ define void @test() {
 ; CHECK-NO-LWM-SWM-LABEL: test_pcrel:
 ; CHECK-NO-PCREL-LABEL: test_pcrel:
 
-define i32 @test_pcrel() {
+define i32 @test_pcrel() optsize {
 
 ; CHECK: lwpc {{.*}}, a+8
 ; CHECK-NO-SAVE-RESTORE: lwpc {{.*}}, a+8
@@ -102,7 +102,7 @@ declare i32 @bar(i32, i32)
 ; CHECK-LABEL: movep:
 ; CHECK-NO-PCREL-LABEL: movep:
 
-define void @movep(i32 %a, i32 %b, i32 %c, i32 %d) {
+define void @movep(i32 %a, i32 %b, i32 %c, i32 %d) optsize {
 ; CHECK-NO-MOVE-NOT: movep
 ; CHECK: movep $s1, $s0, $a0, $a1
 ; CHECK: movep $a0, $a1, $a2, $a3

--- a/llvm/test/CodeGen/Mips/nanomips/divrem.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/divrem.ll
@@ -3,7 +3,7 @@
 ; Make sure to generate __udivmoddi4 libcall when udiv and urem 
 ; instructions with the same operands are present 
 ; and the operands are of type int64
-define void @test1(i64 %a, i64 %b, i64* %divmod) {    
+define void @test1(i64 %a, i64 %b, i64* %divmod) optsize {
   ; CHECK: save	16, $ra, $s0
   ; CHECK: move	$s0, $a4
   ; CHECK: move	$a4, $sp
@@ -24,7 +24,7 @@ define void @test1(i64 %a, i64 %b, i64* %divmod) {
 
 ; Make sure to generate __umoddi3 libcall when only urem is present
 ; and the operands are of type int64
-define void @test2(i64 %a, i64 %b, i64* %divmod) {
+define void @test2(i64 %a, i64 %b, i64* %divmod) optsize {
 	; CHECK: save	16, $ra, $s0
 	; CHECK: move	$s0, $a4
 	; CHECK: balc	__umoddi3
@@ -38,7 +38,7 @@ define void @test2(i64 %a, i64 %b, i64* %divmod) {
 
 ; Make sure to generate __udivdi3 libcall when only udiv is present
 ; and the operands are of type int64
-define void @test3(i64 %a, i64 %b, i64* %divmod) {
+define void @test3(i64 %a, i64 %b, i64* %divmod) optsize {
 	; CHECK: save	16, $ra, $s0
 	; CHECK: move	$s0, $a4
 	; CHECK: balc	__udivdi3
@@ -51,7 +51,7 @@ define void @test3(i64 %a, i64 %b, i64* %divmod) {
 
 ; If urem is expanded into mul+sub and the operands 
 ; are of type int64, make sure to stay that way
-define void @test4(i64 %a, i64 %b, i64* %divmod) {
+define void @test4(i64 %a, i64 %b, i64* %divmod) optsize {
   ; CHECK: save	32, $ra, $s0, $s1, $s2, $s3, $s4
 	; CHECK: movep	$s1, $s0, $a3, $a4
 	; CHECK: movep	$s4, $s2, $a1, $a2
@@ -85,7 +85,7 @@ define void @test4(i64 %a, i64 %b, i64* %divmod) {
 ; Make sure to generate divu and modu when udiv and urem 
 ; instructions with the same operands are present 
 ; and the operands are of type int32
-define void @test5(i32 %a, i32 %b, i32* %divmod) {
+define void @test5(i32 %a, i32 %b, i32* %divmod) optsize {
   ; CHECK: modu	$a3, $a0, $a1
 	; CHECK: teq	$zero, $a1, 7
 	; CHECK: sw	$a3, 4($a2)
@@ -103,7 +103,7 @@ define void @test5(i32 %a, i32 %b, i32* %divmod) {
 
 ; Make sure to generate modu when only urem is present
 ; and the operands are of type int32
-define  void @test6(i32 %a, i32 %b, i32* %divmod) {
+define  void @test6(i32 %a, i32 %b, i32* %divmod) optsize {
   ; CHECK: modu	$a0, $a0, $a1
 	; CHECK: teq	$zero, $a1, 7
 	; CHECK: sw	$a0, 4($a2)
@@ -116,7 +116,7 @@ define  void @test6(i32 %a, i32 %b, i32* %divmod) {
 
 ; Make sure to generate divu when only udiv is present
 ; and the operands are of type int32
-define void @test7(i32 %a, i32 %b, i32* %divmod) {
+define void @test7(i32 %a, i32 %b, i32* %divmod) optsize {
   ; CHECK: divu	$a0, $a0, $a1
 	; CHECK: teq	$zero, $a1, 7
 	; CHECK: sw	$a0, 0($a2)
@@ -128,7 +128,7 @@ define void @test7(i32 %a, i32 %b, i32* %divmod) {
 
 ; If urem is expanded into mul+sub and the operands 
 ; are of type int32, make sure to stay that way.
-define void @test8(i32 %a, i32 %b, i32* %divmod) {
+define void @test8(i32 %a, i32 %b, i32* %divmod) optsize {
   ; CHECK: divu	$a3, $a0, $a1
 	; CHECK: teq	$zero, $a1, 7
 	; CHECK: sw	$a3, 0($a2)

--- a/llvm/test/CodeGen/Mips/nanomips/loadstoremultiple.ll
+++ b/llvm/test/CodeGen/Mips/nanomips/loadstoremultiple.ll
@@ -1,6 +1,6 @@
 ; RUN: llc -mtriple=nanomips -asm-show-inst -verify-machineinstrs < %s | FileCheck %s
 
-define void @test4(i32 %n, ...) {
+define void @test4(i32 %n, ...) optsize {
 ; CHECK: swm $a1, 4($sp), 7
   call void asm sideeffect "", ""()
   ret void
@@ -8,7 +8,7 @@ define void @test4(i32 %n, ...) {
 
 %struct.bar = type { i32, i32, i32 }
 
-define void @square(%struct.bar* %ints) {
+define void @square(%struct.bar* %ints) optsize {
 ; CHECK: lwm $a1, 0($a0), 2
   %a = getelementptr inbounds %struct.bar, %struct.bar* %ints, i32 0, i32 0
   %1 = load i32, i32* %a, align 4


### PR DESCRIPTION
These changes fix the following failing tests on ```nanomips``` branch when running ninja ```check-all```:
- LLVM :: CodeGen/Mips/hf16call32.ll
- LLVM :: CodeGen/Mips/hf16call32_body.ll 
- LLVM :: CodeGen/Mips/hf1_body.ll
- LLVM :: CodeGen/Mips/inlineasm-constraint.ll
- LLVM :: CodeGen/Mips/inlineasm-operand-code.ll
- LLVM :: CodeGen/Mips/nanomips/disable_optimizers.ll
- LLVM :: CodeGen/Mips/nanomips/divrem.ll
- LLVM :: CodeGen/Mips/nanomips/loadstoremultiple.ll

The following tests still fail, but it is confirmed that they fail due to the new memcopy heuristics by reverting memcpy changes:
- Clang :: CodeGenCXX/auto-var-init.cpp
- LLVM :: Transforms/MemCpyOpt/form-memset.ll
- LLVM :: Transforms/MemCpyOpt/merge-into-memset.ll
- LLVM :: Transforms/MemCpyOpt/profitable-memset.ll