### PR TITLE
update_llc_test_checks.py script fix

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_generated_funcs.ll.generated.expected
@@ -82,15 +82,15 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    str w8, [sp, #16]
 ; CHECK-NEXT:    b .LBB0_5
 ; CHECK-NEXT:  .LBB0_3:
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    ldur w8, [x29, #-8]
 ; CHECK-NEXT:    cbnz w8, .LBB0_2
 ; CHECK-NEXT:  .LBB0_4:
 ; CHECK-NEXT:    mov w8, #1
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  .LBB0_5:
 ; CHECK-NEXT:    ldp x29, x30, [sp, #32] // 16-byte Folded Reload
-; CHECK-NEXT:    b OUTLINED_FUNCTION_1
+; CHECK-NEXT:    b OUTLINED_FUNCTION[[SUFFIX1:.*]]
 ;
 ; CHECK-LABEL: main:
 ; CHECK:       // %bb.0:
@@ -114,9 +114,9 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    stp w10, w9, [x29, #-12]
 ; CHECK-NEXT:    ldp x29, x30, [sp, #32] // 16-byte Folded Reload
 ; CHECK-NEXT:    stp w12, w11, [sp, #12]
-; CHECK-NEXT:    b OUTLINED_FUNCTION_1
+; CHECK-NEXT:    b OUTLINED_FUNCTION[[SUFFIX1]]
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_0:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX0]]:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov w9, #2
 ; CHECK-NEXT:    mov w10, #3
@@ -125,7 +125,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    stp w11, w10, [sp, #12]
 ; CHECK-NEXT:    ret
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_1:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX1]]:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov w0, wzr
 ; CHECK-NEXT:    add sp, sp, #48 // =48

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/aarch64_generated_funcs.ll.nogenerated.expected
@@ -23,15 +23,15 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    str w8, [sp, #16]
 ; CHECK-NEXT:    b .LBB0_5
 ; CHECK-NEXT:  .LBB0_3:
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    ldur w8, [x29, #-8]
 ; CHECK-NEXT:    cbnz w8, .LBB0_2
 ; CHECK-NEXT:  .LBB0_4:
 ; CHECK-NEXT:    mov w8, #1
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  .LBB0_5:
 ; CHECK-NEXT:    ldp x29, x30, [sp, #32] // 16-byte Folded Reload
-; CHECK-NEXT:    b OUTLINED_FUNCTION_1
+; CHECK-NEXT:    b OUTLINED_FUNCTION[[SUFFIX1:.*]]
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4
@@ -91,7 +91,7 @@ define dso_local i32 @main() #0 {
 ; CHECK-NEXT:    stp w10, w9, [x29, #-12]
 ; CHECK-NEXT:    ldp x29, x30, [sp, #32] // 16-byte Folded Reload
 ; CHECK-NEXT:    stp w12, w11, [sp, #12]
-; CHECK-NEXT:    b OUTLINED_FUNCTION_1
+; CHECK-NEXT:    b OUTLINED_FUNCTION[[SUFFIX1]]
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.generated.expected
@@ -76,7 +76,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    b .LBB0_3
 ; CHECK-NEXT:  .LBB0_2:
 ; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    mov lr, r1
 ; CHECK-NEXT:  .LBB0_3:
 ; CHECK-NEXT:    ldr r0, [sp, #12]
@@ -88,7 +88,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    b .LBB0_6
 ; CHECK-NEXT:  .LBB0_5:
 ; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:    mov lr, r1
 ; CHECK-NEXT:  .LBB0_6:
 ; CHECK-NEXT:    mov r0, #0
@@ -124,7 +124,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:  .LCPI1_0:
 ; CHECK-NEXT:    .long x
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_0:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX0]]:
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    mov r0, #2
 ; CHECK-NEXT:    str r0, [sp, #8]

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/arm_generated_funcs.ll.nogenerated.expected
@@ -17,7 +17,7 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    b .LBB0_3
 ; CHECK-NEXT:  .LBB0_2:
 ; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    mov lr, r1
 ; CHECK-NEXT:  .LBB0_3:
 ; CHECK-NEXT:    ldr r0, [sp, #12]
@@ -29,7 +29,7 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    b .LBB0_6
 ; CHECK-NEXT:  .LBB0_5:
 ; CHECK-NEXT:    mov r1, lr
-; CHECK-NEXT:    bl OUTLINED_FUNCTION_0
+; CHECK-NEXT:    bl OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:    mov lr, r1
 ; CHECK-NEXT:  .LBB0_6:
 ; CHECK-NEXT:    mov r0, #0

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/x86_generated_funcs.ll.generated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/x86_generated_funcs.ll.generated.expected
@@ -83,11 +83,11 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    movl $1, -4(%rbp)
 ; CHECK-NEXT:    jmp .LBB0_6
 ; CHECK-NEXT:  .LBB0_1:
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_0
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    cmpl $0, -8(%rbp)
 ; CHECK-NEXT:    jne .LBB0_5
 ; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_0
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  .LBB0_6:
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    addq $20, %rsp
@@ -104,18 +104,18 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    .cfi_def_cfa_register %rbp
 ; CHECK-NEXT:    subq $20, %rsp
 ; CHECK-NEXT:    movl $0, -20(%rbp)
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_1
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX1:.*]]
 ; CHECK-NEXT:    movl $1, x(%rip)
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_1
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX1]]
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    addq $20, %rsp
 ; CHECK-NEXT:    popq %rbp
 ; CHECK-NEXT:    .cfi_def_cfa %rsp, 8
 ; CHECK-NEXT:    retq
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_0:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX0]]:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    movl $1, -8(%rbp)
 ; CHECK-NEXT:    movl $2, -16(%rbp)
@@ -123,7 +123,7 @@ attributes #0 = { noredzone nounwind ssp uwtable "frame-pointer"="all" }
 ; CHECK-NEXT:    movl $4, -12(%rbp)
 ; CHECK-NEXT:    retq
 ;
-; CHECK-LABEL: OUTLINED_FUNCTION_1:
+; CHECK: OUTLINED_FUNCTION[[SUFFIX1]]:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    movl $1, -16(%rbp)
 ; CHECK-NEXT:    movl $2, -12(%rbp)

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/x86_generated_funcs.ll.nogenerated.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/Inputs/x86_generated_funcs.ll.nogenerated.expected
@@ -24,11 +24,11 @@ define dso_local i32 @check_boundaries() #0 {
 ; CHECK-NEXT:    movl $1, -4(%rbp)
 ; CHECK-NEXT:    jmp .LBB0_6
 ; CHECK-NEXT:  .LBB0_1:
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_0
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX0:.*]]
 ; CHECK-NEXT:    cmpl $0, -8(%rbp)
 ; CHECK-NEXT:    jne .LBB0_5
 ; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_0
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX0]]
 ; CHECK-NEXT:  .LBB0_6:
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    addq $20, %rsp
@@ -81,11 +81,11 @@ define dso_local i32 @main() #0 {
 ; CHECK-NEXT:    .cfi_def_cfa_register %rbp
 ; CHECK-NEXT:    subq $20, %rsp
 ; CHECK-NEXT:    movl $0, -20(%rbp)
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_1
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX1:.*]]
 ; CHECK-NEXT:    movl $1, x(%rip)
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    callq OUTLINED_FUNCTION_1
+; CHECK-NEXT:    callq OUTLINED_FUNCTION[[SUFFIX1]]
 ; CHECK-NEXT:    xorl %eax, %eax
 ; CHECK-NEXT:    addq $20, %rsp
 ; CHECK-NEXT:    popq %rbp

--- a/llvm/utils/UpdateTestChecks/common.py
+++ b/llvm/utils/UpdateTestChecks/common.py
@@ -20,6 +20,7 @@ _verbose = False
 _prefix_filecheck_ir_name = ''
 
 outlined_fn_to_filecheck_var = {}
+outlined_function_counter = 0
 
 def parse_commandline_args(parser):
   parser.add_argument('--include-generated-funcs', action='store_true',
@@ -633,8 +634,7 @@ def generalize_check_lines(lines, is_analyze, vars_seen, global_vars_seen):
 
 def add_checks(output_lines, comment_marker, prefix_list, func_dict, func_name, check_label_format, is_asm, is_analyze, global_vars_seen_dict):
   global outlined_function_counter
-  outlined_function_counter = 0
-
+  global outlined_fn_to_filecheck_var
   # prefix_exclusions are prefixes we cannot use to print the function because it doesn't exist in run lines that use these prefixes as well.
   prefix_exclusions = set()
   printed_prefixes = []


### PR DESCRIPTION
This fixes tests that are failing after ```update_llc_test_checks.py``` script improvements (introduced in #13). The failing tests are the following:
- LLVM :: tools/UpdateTestChecks/update_llc_test_checks/aarch64_generated_funcs.test
- LLVM :: tools/UpdateTestChecks/update_llc_test_checks/arm_generated_funcs.test
- LLVM :: tools/UpdateTestChecks/update_llc_test_checks/x86_generated_funcs.test

Since target check is removed inside ```update_llc_test_checks.py``` script, expected outputs in ```generated_funcs``` tests for all targets should have been changed as well. Those changes are introduced by this commit. 
