### PR TITLE
nanomips: Add scheduling model for i7200 processor

### DIFF
--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -578,7 +578,7 @@ InstrBuilder::createInstrDescImpl(const MCInst &MCI) {
   ID->NumMicroOps = SCDesc.NumMicroOps;
   ID->SchedClassID = SchedClassID;
 
-  if (MCDesc.isCall() && FirstCallInst) {
+  if (MCDesc.isCall() && FirstCallInst && !STI.getTargetTriple().isNanoMips()) {
     // We don't correctly model calls.
     WithColor::warning() << "found a call in the input assembly sequence.\n";
     WithColor::note() << "call instructions are not correctly modeled. "

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -162,7 +162,7 @@ def FeatureNMS1        : SubtargetFeature<"nms1", "MipsArchVersion",
                                 "NanoMips ISA Support [experimental]">;
 def FeatureI7200       : SubtargetFeature<"i7200", "MipsArchVersion",
                                 "NanoMips",
-                                "NanoMips ISA Support [experimental]">;
+                                "NanoMips ISA Support [experimental]", [FeatureNanoMips]>;
 def FeatureSym32       : SubtargetFeature<"sym32", "HasSym32", "true",
                                           "Symbols are 32 bit on Mips64">;
 
@@ -238,6 +238,7 @@ include "MipsRegisterBanks.td"
 
 // Avoid forward declaration issues.
 include "MipsScheduleP5600.td"
+include "MipsScheduleI7200.td"
 include "MipsScheduleGeneric.td"
 
 def MipsInstrInfo : InstrInfo;
@@ -275,7 +276,7 @@ def : Proc<"octeon+", [FeatureMips64r2, FeatureCnMips, FeatureCnMipsP]>;
 def : ProcessorModel<"p5600", MipsP5600Model, [ImplP5600]>;
 def : Proc<"nanomips", [FeatureNanoMips]>;
 def : Proc<"nms1", [FeatureNanoMips]>;
-def : Proc<"i7200", [FeatureNanoMips]>;
+def : ProcessorModel<"i7200", MipsI7200Model, [FeatureI7200]>;
 
 def MipsAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -276,7 +276,7 @@ def : Proc<"octeon+", [FeatureMips64r2, FeatureCnMips, FeatureCnMipsP]>;
 def : ProcessorModel<"p5600", MipsP5600Model, [ImplP5600]>;
 def : Proc<"nanomips", [FeatureNanoMips]>;
 def : Proc<"nms1", [FeatureNanoMips]>;
-def : ProcessorModel<"i7200", MipsI7200Model, [FeatureI7200]>;
+def : ProcessorModel<"i7200", MipsI7200Model, [FeatureI7200, FeatureGINV]>;
 
 def MipsAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;

--- a/llvm/lib/Target/Mips/MipsScheduleI7200.td
+++ b/llvm/lib/Target/Mips/MipsScheduleI7200.td
@@ -1,0 +1,143 @@
+def MipsI7200Model : SchedMachineModel {
+  int IssueWidth = 2;
+  int MicroOpBufferSize = 48;
+  int LoadLatency = 4;
+  int MispredictPenalty = 8;
+
+  let CompleteModel = 1;
+  let FullInstRWOverlapCheck = 1;
+
+  // Disable all except nanomips instructions.
+  list<Predicate> UnsupportedFeatures = [
+    HasMips2, HasMips3_32, HasMips3_32r2, HasMips3, HasMips4_32, HasMips4_32r2,
+    HasMips32, HasMips32r2, HasMips32r5, HasMips32r6,
+    HasMips64, HasMips64r2, HasMips64r5, HasMips64r6,
+    IsGP64bit, IsFP64bit, IsPTR64bit, IsNotSoftFloat,
+    InMicroMips, InMips16Mode, HasCnMips, HasCnMipsP,
+    HasDSP, HasDSPR2, HasMips3D, HasMT,
+    HasCRC, HasStdEnc, HasMSA
+  ];
+}
+
+// Define processor resources.
+let SchedModel = MipsI7200Model, BufferSize = 16 in {
+  def i7200GpMulDiv : ProcResource<1>;
+
+  def i7200Agen : ProcResource<1>;
+  def i7200Alu1 : ProcResource<1>;
+  def i7200Lsu : ProcResource<1>;
+
+  def i7200Control : ProcResource<1>;
+  def i7200Ctu : ProcResource<1>;
+  def i7200Alu0 : ProcResource<1>;
+
+  def i7200Alu : ProcResGroup<[i7200Alu0, i7200Alu1]>;
+}
+
+// Define read classes for ReadAdvance.
+def I7200ReadLoad : SchedRead;
+def I7200ReadStore : SchedRead;
+
+// Define instruction schedules.
+let SchedModel = MipsI7200Model in {
+
+// Arithmetic and logical instructions.
+def I7200WriteALU : SchedWriteRes<[i7200Alu]>;
+def : InstRW<[I7200WriteALU], (instrs
+  ADD_NM, ADDiu_NM, ADDIU48_NM, ADDu_NM, SUB_NM, SUBu_NM,
+  AND_NM, AND16_NM, ANDI_NM, OR_NM, OR16_NM, ORI_NM, XOR_NM, XOR16_NM, XORI_NM, NOR_NM, NOT_NM,
+  SRA, SRAV, SRL, SRLV, SLL, SLLV, SRA_NM, SRAV_NM, SRL_NM, SRLV_NM, SLL_NM, SLLV_NM, 
+  SLT, SLTi, SLTiu, SLTu, SLT_NM, SLTI_NM, SLTIU_NM, SLTU_NM, SEQI_NM,
+  LA_NM, Li_NM, SEB_NM, SEH_NM,
+  BITREVW_NM, BYTEREVW_NM,
+  MOVE_NM, MOVN_NM, MOVZ_NM,
+  CLZ_NM, CLZ, CLO_NM, CLO,
+  EXT_NM, INS_NM,
+  LSA_NM, SAVE_NM, RESTORE_NM,
+  ALUIPC_NM, ROTR_NM, ROTRV_NM
+)>;
+
+// Movep instruction.
+def I7200WriteMovep : SchedWriteRes<[i7200Control, i7200Agen, i7200Alu0, i7200Alu1]> {
+  let Latency = 1;
+}
+def : InstRW<[I7200WriteMovep], (instrs MOVEP_NM)>;
+
+// Mul instructions.
+def I7200WriteMul : SchedWriteRes<[i7200Agen, i7200GpMulDiv]> {
+  let Latency = 5;
+  let ResourceCycles = [1, 1];
+}
+def : InstRW<[I7200WriteMul], (instrs MUL_NM, MULU_NM, MUH_NM, MUHU_NM)>;
+
+// Div instructions.
+def I7200WriteDiv : SchedWriteRes<[i7200GpMulDiv]> {
+  let Latency = 32;
+  let ResourceCycles = [32];
+}
+def : InstRW<[I7200WriteDiv], (instrs DIV_NM, DIVU_NM, MOD_NM, MODU_NM)>;
+
+// Load instructions.
+def I7200WriteLoad : SchedWriteRes<[i7200Agen, i7200Lsu]> {
+  let Latency = 2;
+  let ResourceCycles = [1, 1];
+}
+def : InstRW<[I7200WriteLoad, I7200ReadLoad], (instrs
+  LB_NM, LBs9_NM, LBU_NM, LBUs9_NM, LH_NM, LHs9_NM, LHU_NM, LHUs9_NM, LW_NM, LWs9_NM,
+  LBX_NM, LBUX_NM, LWX_NM, LWXS_NM, LHX_NM, LHXS_NM, LHUX_NM, LHUXS_NM, LWM_NM,
+  LWPC_NM, LWGP_NM, UALW_NM, UALH_NM, UALWM_NM
+)>;
+
+// Store instructions.
+def I7200WriteStore : SchedWriteRes<[i7200Agen, i7200Lsu]> {
+  let Latency = 1;
+  let ResourceCycles = [1, 1];
+}
+def : InstRW<[I7200WriteStore, I7200ReadStore], (instrs 
+  SB_NM, SBs9_NM, SH_NM, SHs9_NM, SW_NM, SWs9_NM,
+  SBX_NM, SHX_NM, SHXS_NM, SWX_NM, SWXS_NM,
+  SWPC_NM, SWM_NM, UASW_NM, UASH_NM, UASWM_NM
+)>;
+
+// Branch and jump instructions.
+def I7200WriteBranch : SchedWriteRes<[i7200Control, i7200Ctu]> {
+  let Latency = 1;
+  let ResourceCycles = [1, 1];
+}
+def : InstRW<[I7200WriteBranch], (instrs
+  BRSC_NM, BC_NM, BEQC_NM, BEQIC_NM, BEQZC_NM, BGEC_NM, BGEIC_NM, BGEIUC_NM, BGEUC_NM,
+  BLTC_NM, BLTIC_NM, BLTIUC_NM, BLTUC_NM, BNEC_NM, BNEIC_NM, BNEZC_NM,
+  BBNEZC_NM, BBEQZC_NM, JALRC_NM, JRC_NM, RESTOREJRC_NM, BALC_NM, MOVEBALC_NM
+)>;
+
+// Unclear how to schedule these. Use WriteALU for now.
+def : InstRW<[I7200WriteALU], (instrs TEQ_NM, TNE_NM, RDHWR_NM)>;
+
+// Pseudo instructions.
+def : InstRW<[I7200WriteALU], (instrs COPY)>;
+def : InstRW<[I7200WriteBranch], (instrs
+  RetRA, PseudoReturn, PseudoReturnNM, PseudoIndirectBranchNM,
+  TAILCALL_NM, TAILCALLREG_NM, JALRCPseudo, JALRHBPseudo, ERet
+)>;
+
+// These are copied from the generic model.
+def I7200Atomic : ProcResource<1> { let BufferSize = 1; }
+def I7200WriteAtomic : SchedWriteRes<[I7200Atomic]> { let Latency = 2; }
+def : InstRW<[I7200WriteAtomic],
+    (instregex "^ATOMIC_SWAP_I(8|16|32|64)_POSTRA$")>;
+def : InstRW<[I7200WriteAtomic],
+    (instregex "^ATOMIC_CMP_SWAP_I(8|16|32|64)_POSTRA$")>;
+def : InstRW<[I7200WriteAtomic],
+    (instregex "^ATOMIC_LOAD_(ADD|SUB|AND|OR|XOR|NAND|MIN|MAX|UMIN|UMAX)"
+               "_I(8|16|32|64)_POSTRA$")>;
+
+
+// Define bypasses.
+// Load and store instructions take 1 cycle longer if their operand was
+// created by a load, arithmetic or move operation.
+def : ReadAdvance<I7200ReadLoad, -1, [I7200WriteLoad, I7200WriteALU, 
+                                      I7200WriteMovep, I7200WriteMul]>;
+def : ReadAdvance<I7200ReadStore, -1, [I7200WriteLoad, I7200WriteALU,
+                                       I7200WriteMovep, I7200WriteMul]>;
+
+}

--- a/llvm/lib/Target/Mips/MipsScheduleI7200.td
+++ b/llvm/lib/Target/Mips/MipsScheduleI7200.td
@@ -1,7 +1,7 @@
 def MipsI7200Model : SchedMachineModel {
   int IssueWidth = 2;
-  int MicroOpBufferSize = 48;
-  int LoadLatency = 4;
+  int MicroOpBufferSize = 0;
+  int LoadLatency = 2;
   int MispredictPenalty = 8;
 
   let CompleteModel = 1;
@@ -20,7 +20,7 @@ def MipsI7200Model : SchedMachineModel {
 }
 
 // Define processor resources.
-let SchedModel = MipsI7200Model, BufferSize = 16 in {
+let SchedModel = MipsI7200Model, BufferSize = 0 in {
   def i7200GpMulDiv : ProcResource<1>;
 
   def i7200Agen : ProcResource<1>;
@@ -37,6 +37,7 @@ let SchedModel = MipsI7200Model, BufferSize = 16 in {
 // Define read classes for ReadAdvance.
 def I7200ReadLoad : SchedRead;
 def I7200ReadStore : SchedRead;
+def I7200ReadSpecial : SchedRead;
 
 // Define instruction schedules.
 let SchedModel = MipsI7200Model in {
@@ -44,31 +45,34 @@ let SchedModel = MipsI7200Model in {
 // Arithmetic and logical instructions.
 def I7200WriteALU : SchedWriteRes<[i7200Alu]>;
 def : InstRW<[I7200WriteALU], (instrs
-  ADD_NM, ADDiu_NM, ADDIU48_NM, ADDu_NM, SUB_NM, SUBu_NM,
-  AND_NM, AND16_NM, ANDI_NM, OR_NM, OR16_NM, ORI_NM, XOR_NM, XOR16_NM, XORI_NM, NOR_NM, NOT_NM,
-  SRA, SRAV, SRL, SRLV, SLL, SLLV, SRA_NM, SRAV_NM, SRL_NM, SRLV_NM, SLL_NM, SLLV_NM, 
+  ADD_NM, ADDIU_NM, ADDIU48_NM, ADDIUGP48_NM, ADDIUGPB_NM, ADDIUGPW_NM, ADDIUNEG_NM, ADDIUR1SP_NM, ADDIUR2_NM, ADDIURS5_NM,
+  ADDu_NM, ADDu16_NM, ADDu4x4_NM, SUB_NM, SUBu_NM, SUBu16_NM,
+  AND_NM, AND16_NM, ANDI_NM, ANDI16_NM, OR_NM, OR16_NM, ORI_NM, XOR_NM, XOR16_NM, XORI_NM, NOP_NM, NOP32_NM,  NOR_NM, NOT16_NM,
+  SRA, SRAV, SRL, SRLV, SLL, SLL16_NM, SLLV, SRA_NM, SRAV_NM, SRL_NM, SRL16_NM, SRLV_NM, SLL_NM, SLLV_NM, 
   SLT, SLTi, SLTiu, SLTu, SLT_NM, SLTI_NM, SLTIU_NM, SLTU_NM, SEQI_NM,
-  LA_NM, Li_NM, SEB_NM, SEH_NM,
+  SEB_NM, SEH_NM, SOV_NM,
   BITREVW_NM, BYTEREVW_NM,
   MOVE_NM, MOVN_NM, MOVZ_NM,
   CLZ_NM, CLZ, CLO_NM, CLO,
-  EXT_NM, INS_NM,
-  LSA_NM, SAVE_NM, RESTORE_NM,
-  ALUIPC_NM, ROTR_NM, ROTRV_NM
+  EXT_NM, EXTW_NM, INS_NM,
+  LSA_NM, SAVE_NM, SAVE16_NM, RESTORE_NM,
+  ALUIPC_NM, ROTR_NM, ROTRV_NM, ROTX_NM,
+  LI16_NM, LI48_NM, LUI_NM,
+  LAPC32_NM, LAPC48_NM
 )>;
 
 // Movep instruction.
 def I7200WriteMovep : SchedWriteRes<[i7200Control, i7200Agen, i7200Alu0, i7200Alu1]> {
   let Latency = 1;
 }
-def : InstRW<[I7200WriteMovep], (instrs MOVEP_NM)>;
+def : InstRW<[I7200WriteMovep], (instrs MOVEP_NM, MOVEPREV_NM)>;
 
 // Mul instructions.
 def I7200WriteMul : SchedWriteRes<[i7200Agen, i7200GpMulDiv]> {
   let Latency = 5;
   let ResourceCycles = [1, 1];
 }
-def : InstRW<[I7200WriteMul], (instrs MUL_NM, MULU_NM, MUH_NM, MUHU_NM)>;
+def : InstRW<[I7200WriteMul], (instrs MUL_NM, MUL4x4_NM, MULU_NM, MUH_NM, MUHU_NM)>;
 
 // Div instructions.
 def I7200WriteDiv : SchedWriteRes<[i7200GpMulDiv]> {
@@ -83,8 +87,9 @@ def I7200WriteLoad : SchedWriteRes<[i7200Agen, i7200Lsu]> {
   let ResourceCycles = [1, 1];
 }
 def : InstRW<[I7200WriteLoad, I7200ReadLoad], (instrs
-  LB_NM, LBs9_NM, LBU_NM, LBUs9_NM, LH_NM, LHs9_NM, LHU_NM, LHUs9_NM, LW_NM, LWs9_NM,
-  LBX_NM, LBUX_NM, LWX_NM, LWXS_NM, LHX_NM, LHXS_NM, LHUX_NM, LHUXS_NM, LWM_NM,
+  LB_NM, LB16_NM, LBGP_NM, LBs9_NM, LBU_NM, LBU16_NM, LBUGP_NM, LBUs9_NM, LH_NM, LH16_NM, LHGP_NM, LHGP_NM, LHs9_NM,
+  LHU_NM, LHU16_NM, LHUGP_NM, LHUs9_NM, LW_NM, LW16_NM, LW4x4_NM, LWGP16_NM, LWSP16_NM, LWs9_NM,
+  LBX_NM, LBUX_NM, LWX_NM, LWXS_NM, LWXS16_NM, LHX_NM, LHXS_NM, LHUX_NM, LHUXS_NM, LWM_NM,
   LWPC_NM, LWGP_NM, UALW_NM, UALH_NM, UALWM_NM
 )>;
 
@@ -94,7 +99,7 @@ def I7200WriteStore : SchedWriteRes<[i7200Agen, i7200Lsu]> {
   let ResourceCycles = [1, 1];
 }
 def : InstRW<[I7200WriteStore, I7200ReadStore], (instrs 
-  SB_NM, SBs9_NM, SH_NM, SHs9_NM, SW_NM, SWs9_NM,
+  SB_NM, SB16_NM, SBGP_NM, SBs9_NM, SH_NM, SH16_NM, SHGP_NM, SHs9_NM, SW_NM, SWs9_NM, SW16_NM, SW4x4_NM, SWGP_NM, SWGP16_NM, SWSP16_NM,
   SBX_NM, SHX_NM, SHXS_NM, SWX_NM, SWXS_NM,
   SWPC_NM, SWM_NM, UASW_NM, UASH_NM, UASWM_NM
 )>;
@@ -105,9 +110,73 @@ def I7200WriteBranch : SchedWriteRes<[i7200Control, i7200Ctu]> {
   let ResourceCycles = [1, 1];
 }
 def : InstRW<[I7200WriteBranch], (instrs
-  BRSC_NM, BC_NM, BEQC_NM, BEQIC_NM, BEQZC_NM, BGEC_NM, BGEIC_NM, BGEIUC_NM, BGEUC_NM,
-  BLTC_NM, BLTIC_NM, BLTIUC_NM, BLTUC_NM, BNEC_NM, BNEIC_NM, BNEZC_NM,
-  BBNEZC_NM, BBEQZC_NM, JALRC_NM, JRC_NM, RESTOREJRC_NM, BALC_NM, MOVEBALC_NM
+  BRSC_NM, BC_NM, BC16_NM, BEQC_NM, BEQC16_NM, BEQCzero_NM, BEQIC_NM, BEQZC_NM, BEQZC16_NM, BGEC_NM, BGEIC_NM, BGEIUC_NM, BGEUC_NM,
+  BLTC_NM, BLTIC_NM, BLTIUC_NM, BLTUC_NM, BNEC_NM, BNEC16_NM, BNECzero_NM, BNEIC_NM, BNEZC_NM, BNEZC16_NM,
+  BBNEZC_NM, BBEQZC_NM, JALRC_NM, JALRC16_NM, JALRCHB_NM, JRC_NM, RESTOREJRC_NM, RESTOREJRC16_NM, BALC_NM, BALC16_NM, BALRSC_NM, MOVEBALC_NM
+)>;
+
+// Exception instructions.
+def : InstRW<[I7200WriteBranch], (instrs
+  BREAK_NM, BREAK16_NM, SDBBP16_NM, SDBBP_NM, SIGRIE_NM, SYSCALL_NM, SYSCALL16_NM
+)>;
+
+// Cache instructions.
+def I7200WriteCache : SchedWriteRes<[i7200Agen, i7200Lsu, i7200Control]>{
+  let Latency = 2;
+  let ResourceCycles = [1, 1, 1];
+}
+def : InstRW<[I7200WriteCache], (instrs
+  CACHE_NM, PREF_NM, PREFs9_NM, SYNCI_NM, SYNCIs9_NM
+)>;
+
+// Ginvi instruction.
+def I7200WriteGinvi : SchedWriteRes<[i7200Control]>{
+  let Latency = 1;
+  let ResourceCycles = [1];
+}
+def : InstRW<[I7200WriteGinvi], (instrs
+  GINVI_NM
+)>;
+
+//Exception return instructions.
+def : InstRW<[I7200WriteBranch], (instrs
+  DERET_NM, ERET_NM, ERETNC_NM
+)>;
+
+// COP instructions.
+def I7200WriteCOP : SchedWriteRes<[i7200Control]>{
+  let Latency = 2;
+  let ResourceCycles = [2];
+}
+def : InstRW<[I7200WriteCOP], (instrs
+  DI_NM, EI_NM, MTC0_NM, MTC0Sel_NM, MTHC0_NM, MTHC0Sel_NM, MFC0_NM, MFC0Sel_NM, MFHC0_NM, MFHC0Sel_NM, EHB_NM, PAUSE_NM, WAIT_NM
+)>;
+
+// Special instructions.
+def I7200WriteSpecial : SchedWriteRes<[i7200Alu]>{
+  let Latency = 1;
+  let ResourceCycles = [1];
+}
+def : InstRW<[I7200WriteSpecial, I7200ReadSpecial], (instrs
+  RDPGPR_NM, WRPGPR_NM
+)>;
+
+// Sync instruction.
+def I7200WriteSync : SchedWriteRes<[i7200Lsu]>{
+  let Latency = 1;
+  let ResourceCycles = [1];
+}
+def : InstRW<[I7200WriteSync], (instrs
+  SYNC_NM
+)>;
+
+// TLB instructions.
+def I7200WriteTLB : SchedWriteRes<[i7200Control]>{
+  let Latency = 2;
+  let ResourceCycles = [2];
+}
+def : InstRW<[I7200WriteTLB], (instrs
+  TLBINV_NM, TLBINVF_NM, TLBP_NM, TLBR_NM, TLBWI_NM, TLBWR_NM, GINVT_NM
 )>;
 
 // Unclear how to schedule these. Use WriteALU for now.
@@ -117,11 +186,11 @@ def : InstRW<[I7200WriteALU], (instrs TEQ_NM, TNE_NM, RDHWR_NM)>;
 def : InstRW<[I7200WriteALU], (instrs COPY)>;
 def : InstRW<[I7200WriteBranch], (instrs
   RetRA, PseudoReturn, PseudoReturnNM, PseudoIndirectBranchNM,
-  TAILCALL_NM, TAILCALLREG_NM, JALRCPseudo, JALRHBPseudo, ERet
+  TAILCALL_NM, TAILCALLREG_NM, MUSTTAILCALLREG_NM, MUSTTAILCALL_NM, JALRCPseudo, JALRHBPseudo, ERet
 )>;
 
 // These are copied from the generic model.
-def I7200Atomic : ProcResource<1> { let BufferSize = 1; }
+def I7200Atomic : ProcResource<1> { let BufferSize = 0; }
 def I7200WriteAtomic : SchedWriteRes<[I7200Atomic]> { let Latency = 2; }
 def : InstRW<[I7200WriteAtomic],
     (instregex "^ATOMIC_SWAP_I(8|16|32|64)_POSTRA$")>;
@@ -134,10 +203,14 @@ def : InstRW<[I7200WriteAtomic],
 
 // Define bypasses.
 // Load and store instructions take 1 cycle longer if their operand was
-// created by a load, arithmetic or move operation.
-def : ReadAdvance<I7200ReadLoad, -1, [I7200WriteLoad, I7200WriteALU, 
-                                      I7200WriteMovep, I7200WriteMul]>;
+// created by a load, arithmetic, COP or move operation.
+def : ReadAdvance<I7200ReadLoad, -1, [I7200WriteLoad, I7200WriteALU,
+                                      I7200WriteBranch, I7200WriteMul,
+                                      I7200WriteCOP, I7200WriteSpecial,
+                                      I7200WriteMovep, I7200WriteDiv]>;
 def : ReadAdvance<I7200ReadStore, -1, [I7200WriteLoad, I7200WriteALU,
-                                       I7200WriteMovep, I7200WriteMul]>;
-
+                                      I7200WriteBranch, I7200WriteMul,
+                                      I7200WriteCOP, I7200WriteSpecial,
+                                      I7200WriteMovep, I7200WriteDiv]>;
+def : ReadAdvance<I7200ReadSpecial, 1, [I7200WriteMul, I7200WriteDiv]>;
 }

--- a/llvm/test/tools/llvm-mca/nanoMIPS/example1.s
+++ b/llvm/test/tools/llvm-mca/nanoMIPS/example1.s
@@ -1,0 +1,226 @@
+# RUN: llvm-mca -mtriple=nanomips -mcpu=i7200 -iterations=300 -enable-misched -misched-postra < %s | FileCheck %s
+
+	.text
+	.linkrelax
+	.module	softfloat
+	.module	pcrel
+	.file	"primer1.c"
+	.globl	f                               # -- Begin function f
+	.p2align	1
+	.type	f,@function
+	.ent	f
+f:                                      # @f
+	.frame	$sp,16,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -16
+	sw	$a0, 12($sp)
+	move	$a0, $zero
+	sw	$a0, 4($sp)
+	li	$a0, 1
+	sw	$a0, 8($sp)
+	bc	.LBB0_1
+.LBB0_1:                                # =>This Inner Loop Header: Depth=1
+	lw	$a0, 8($sp)
+	lw	$a1, 12($sp)
+	bgec	$a0, $a1, .LBB0_4
+	bc	.LBB0_2
+.LBB0_2:                                #   in Loop: Header=BB0_1 Depth=1
+	lw	$a1, 8($sp)
+	lw	$a0, 4($sp)
+	addu	$a0, $a0, $a1
+	sw	$a0, 4($sp)
+	bc	.LBB0_3
+.LBB0_3:                                #   in Loop: Header=BB0_1 Depth=1
+	lw	$a0, 8($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 8($sp)
+	bc	.LBB0_1
+.LBB0_4:
+	lw	$a0, 4($sp)
+	addiu	$sp, $sp, 16
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	f
+.Lfunc_end0:
+	.size	f, .Lfunc_end0-f
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	1
+	.type	main,@function
+	.ent	main
+main:                                   # @main
+	.frame	$sp,16,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -16
+	sw	$ra, 12($sp)                    # 4-byte Folded Spill
+	move	$a0, $zero
+	sw	$a0, 4($sp)                     # 4-byte Folded Spill
+	sw	$a0, 8($sp)
+	lapc.b	$a0, .L.str
+	balc	printf
+	li	$a0, 25
+	balc	f
+	move	$a1, $a0
+	lapc.b	$a0, .L.str.1
+	balc	printf
+                                        # kill: def $a1_nm killed $a0_nm
+	lw	$a0, 4($sp)                     # 4-byte Folded Reload
+	lw	$ra, 12($sp)                    # 4-byte Folded Reload
+	addiu	$sp, $sp, 16
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	main
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.4,"aMS",@progbits,1
+	.p2align	2
+.L.str:
+	.asciz	"Hello world!\n"
+	.size	.L.str, 14
+
+	.type	.L.str.1,@object                # @.str.1
+	.p2align	2
+.L.str.1:
+	.asciz	"%d\n"
+	.size	.L.str.1, 4
+
+	.ident	"clang version 13.0.0 (https://github.com/MediaTek-Labs/llvm-project.git 591da1c539e7fb4a859b47668b4445d963f6f4f1)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym f
+	.addrsig_sym printf
+	.text
+
+# CHECK:      Iterations:        300
+# CHECK-NEXT: Instructions:      11700
+# CHECK-NEXT: Total Cycles:      96902
+# CHECK-NEXT: Total uOps:        11700
+
+# CHECK:      Dispatch Width:    2
+# CHECK-NEXT: uOps Per Cycle:    0.12
+# CHECK-NEXT: IPC:               0.12
+# CHECK-NEXT: Block RThroughput: 19.5
+
+
+# CHECK:      Instruction Info:
+# CHECK-NEXT: [1]: #uOps
+# CHECK-NEXT: [2]: Latency
+# CHECK-NEXT: [3]: RThroughput
+# CHECK-NEXT: [4]: MayLoad
+# CHECK-NEXT: [5]: MayStore
+# CHECK-NEXT: [6]: HasSideEffects (U)
+
+# CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -16
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 12($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     0.50                  U     li	$a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 12($sp)
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB0_4
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_2
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a0, $a0, $a1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 16
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -16
+# CHECK-NEXT:  1      1     1.00                  U     sw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      1     0.50                  U     li	$a0, 25
+# CHECK-NEXT:  1      1     1.00                        balc	f
+# CHECK-NEXT:  1      1     0.50                  U     move	$a1, $a0
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.1
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 16
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+
+
+# CHECK:      Resources:
+# CHECK-NEXT: [0]   - I7200Atomic
+# CHECK-NEXT: [1]   - i7200Agen
+# CHECK-NEXT: [2]   - i7200Alu0
+# CHECK-NEXT: [3]   - i7200Alu1
+# CHECK-NEXT: [4]   - i7200Control
+# CHECK-NEXT: [5]   - i7200Ctu
+# CHECK-NEXT: [6]   - i7200GpMulDiv
+# CHECK-NEXT: [7]   - i7200Lsu
+
+
+# CHECK:      Resource pressure per iteration:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    
+# CHECK-NEXT:  -     16.00  6.50   6.50   10.00  10.00   -     16.00  
+
+# CHECK:      Resource pressure by instruction:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addiu	$sp, $sp, -16
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 12($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 4($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     li	$a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 12($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB0_4
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addu	$a0, $a0, $a1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 4($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 8($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addiu	$sp, $sp, 16
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addiu	$sp, $sp, -16
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$ra, 12($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     lapc.b	$a0, .L.str
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     li	$a0, 25
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	f
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     move	$a1, $a0
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     lapc.b	$a0, .L.str.1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$ra, 12($sp)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     addiu	$sp, $sp, 16
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra

--- a/llvm/test/tools/llvm-mca/nanoMIPS/example2.s
+++ b/llvm/test/tools/llvm-mca/nanoMIPS/example2.s
@@ -1,0 +1,894 @@
+# RUN: llvm-mca -mtriple=nanomips -mcpu=i7200 -iterations=300 -enable-misched -misched-postra < %s | FileCheck %s
+
+	.text
+	.linkrelax
+	.module	softfloat
+	.module	pcrel
+	.file	"primer4.c"
+	.globl	fillArray                       # -- Begin function fillArray
+	.p2align	1
+	.type	fillArray,@function
+	.ent	fillArray
+fillArray:                              # @fillArray
+	.frame	$sp,16,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -16
+	sw	$ra, 12($sp)                    # 4-byte Folded Spill
+	sw	$a0, 8($sp)
+	sw	$a1, 4($sp)
+	move	$a0, $zero
+	sw	$a0, 0($sp)
+	bc	.LBB0_1
+.LBB0_1:                                # =>This Inner Loop Header: Depth=1
+	lw	$a0, 0($sp)
+	lw	$a1, 4($sp)
+	bgec	$a0, $a1, .LBB0_4
+	bc	.LBB0_2
+.LBB0_2:                                #   in Loop: Header=BB0_1 Depth=1
+	balc	rand
+	li	$a1, 274877907
+	muh	$a1, $a0, $a1
+	srl	$a2, $a1, 31
+	sra	$a1, $a1, 6
+	addu	$a2, $a1, $a2
+	sll	$a1, $a2, 4
+	lsa	$a1, $a2, $a1, 3
+	sll	$a2, $a2, 10
+	subu	$a1, $a1, $a2
+	addu	$a0, $a0, $a1
+	lw	$a1, 8($sp)
+	lw	$a2, 0($sp)
+	swxs	$a0, $a2($a1)
+	bc	.LBB0_3
+.LBB0_3:                                #   in Loop: Header=BB0_1 Depth=1
+	lw	$a0, 0($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 0($sp)
+	bc	.LBB0_1
+.LBB0_4:
+	lw	$ra, 12($sp)                    # 4-byte Folded Reload
+	addiu	$sp, $sp, 16
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	fillArray
+.Lfunc_end0:
+	.size	fillArray, .Lfunc_end0-fillArray
+                                        # -- End function
+	.globl	printArray                      # -- Begin function printArray
+	.p2align	1
+	.type	printArray,@function
+	.ent	printArray
+printArray:                             # @printArray
+	.frame	$sp,16,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -16
+	sw	$ra, 12($sp)                    # 4-byte Folded Spill
+	sw	$a0, 8($sp)
+	sw	$a1, 4($sp)
+	move	$a0, $zero
+	sw	$a0, 0($sp)
+	bc	.LBB1_1
+.LBB1_1:                                # =>This Inner Loop Header: Depth=1
+	lw	$a0, 0($sp)
+	lw	$a1, 4($sp)
+	bgec	$a0, $a1, .LBB1_4
+	bc	.LBB1_2
+.LBB1_2:                                #   in Loop: Header=BB1_1 Depth=1
+	lw	$a0, 8($sp)
+	lw	$a1, 0($sp)
+	lwxs	$a1, $a1($a0)
+	lapc.b	$a0, .L.str.6
+	balc	printf
+	bc	.LBB1_3
+.LBB1_3:                                #   in Loop: Header=BB1_1 Depth=1
+	lw	$a0, 0($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 0($sp)
+	bc	.LBB1_1
+.LBB1_4:
+	lapc.b	$a0, .L.str.7
+	balc	printf
+	lw	$ra, 12($sp)                    # 4-byte Folded Reload
+	addiu	$sp, $sp, 16
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	printArray
+.Lfunc_end1:
+	.size	printArray, .Lfunc_end1-printArray
+                                        # -- End function
+	.globl	sortArray                       # -- Begin function sortArray
+	.p2align	1
+	.type	sortArray,@function
+	.ent	sortArray
+sortArray:                              # @sortArray
+	.frame	$sp,32,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -32
+	sw	$a0, 28($sp)
+	sw	$a1, 24($sp)
+	move	$a0, $zero
+	sw	$a0, 20($sp)
+	bc	.LBB2_1
+.LBB2_1:                                # =>This Loop Header: Depth=1
+                                        #     Child Loop BB2_3 Depth 2
+	lw	$a0, 20($sp)
+	lw	$a1, 24($sp)
+	addiu	$a1, $a1, -1
+	bgec	$a0, $a1, .LBB2_10
+	bc	.LBB2_2
+.LBB2_2:                                #   in Loop: Header=BB2_1 Depth=1
+	move	$a0, $zero
+	sw	$a0, 16($sp)
+	bc	.LBB2_3
+.LBB2_3:                                #   Parent Loop BB2_1 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	lw	$a0, 16($sp)
+	lw	$a2, 24($sp)
+	lw	$a1, 20($sp)
+	not	$a1, $a1
+	addu	$a1, $a1, $a2
+	bgec	$a0, $a1, .LBB2_8
+	bc	.LBB2_4
+.LBB2_4:                                #   in Loop: Header=BB2_3 Depth=2
+	lw	$a1, 28($sp)
+	lw	$a2, 16($sp)
+	lsa	$a0, $a2, $a1, 2
+	lwxs	$a1, $a2($a1)
+	lw	$a0, 4($a0)
+	bgec	$a0, $a1, .LBB2_6
+	bc	.LBB2_5
+.LBB2_5:                                #   in Loop: Header=BB2_3 Depth=2
+	lw	$a0, 28($sp)
+	lw	$a1, 16($sp)
+	lwxs	$a0, $a1($a0)
+	sw	$a0, 12($sp)
+	lw	$a1, 28($sp)
+	lw	$a2, 16($sp)
+	lsa	$a0, $a2, $a1, 2
+	lw	$a0, 4($a0)
+	swxs	$a0, $a2($a1)
+	lw	$a0, 12($sp)
+	lw	$a2, 28($sp)
+	lw	$a1, 16($sp)
+	lsa	$a1, $a1, $a2, 2
+	sw	$a0, 4($a1)
+	bc	.LBB2_6
+.LBB2_6:                                #   in Loop: Header=BB2_3 Depth=2
+	bc	.LBB2_7
+.LBB2_7:                                #   in Loop: Header=BB2_3 Depth=2
+	lw	$a0, 16($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 16($sp)
+	bc	.LBB2_3
+.LBB2_8:                                #   in Loop: Header=BB2_1 Depth=1
+	bc	.LBB2_9
+.LBB2_9:                                #   in Loop: Header=BB2_1 Depth=1
+	lw	$a0, 20($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 20($sp)
+	bc	.LBB2_1
+.LBB2_10:
+	addiu	$sp, $sp, 32
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	sortArray
+.Lfunc_end2:
+	.size	sortArray, .Lfunc_end2-sortArray
+                                        # -- End function
+	.globl	binarySearch                    # -- Begin function binarySearch
+	.p2align	1
+	.type	binarySearch,@function
+	.ent	binarySearch
+binarySearch:                           # @binarySearch
+	.frame	$sp,32,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -32
+	sw	$a0, 24($sp)
+	sw	$a1, 20($sp)
+	sw	$a2, 16($sp)
+	move	$a0, $zero
+	sw	$a0, 12($sp)
+	lw	$a0, 20($sp)
+	addiu	$a0, $a0, -1
+	sw	$a0, 8($sp)
+	bc	.LBB3_1
+.LBB3_1:                                # =>This Inner Loop Header: Depth=1
+	lw	$a1, 12($sp)
+	lw	$a0, 8($sp)
+	bltc	$a0, $a1, .LBB3_8
+	bc	.LBB3_2
+.LBB3_2:                                #   in Loop: Header=BB3_1 Depth=1
+	lw	$a0, 12($sp)
+	lw	$a1, 8($sp)
+	subu	$a1, $a1, $a0
+	srl	$a2, $a1, 31
+	addu	$a1, $a1, $a2
+	sra	$a1, $a1, 1
+	addu	$a0, $a0, $a1
+	sw	$a0, 4($sp)
+	lw	$a0, 24($sp)
+	lw	$a1, 4($sp)
+	lwxs	$a0, $a1($a0)
+	lw	$a1, 16($sp)
+	bnec	$a0, $a1, .LBB3_4
+	bc	.LBB3_3
+.LBB3_3:
+	lw	$a0, 4($sp)
+	sw	$a0, 28($sp)
+	bc	.LBB3_9
+.LBB3_4:                                #   in Loop: Header=BB3_1 Depth=1
+	lw	$a0, 24($sp)
+	lw	$a1, 4($sp)
+	lwxs	$a0, $a1($a0)
+	lw	$a1, 16($sp)
+	bgec	$a0, $a1, .LBB3_6
+	bc	.LBB3_5
+.LBB3_5:                                #   in Loop: Header=BB3_1 Depth=1
+	lw	$a0, 4($sp)
+	addiu	$a0, $a0, 1
+	sw	$a0, 12($sp)
+	bc	.LBB3_7
+.LBB3_6:                                #   in Loop: Header=BB3_1 Depth=1
+	lw	$a0, 4($sp)
+	addiu	$a0, $a0, -1
+	sw	$a0, 8($sp)
+	bc	.LBB3_7
+.LBB3_7:                                #   in Loop: Header=BB3_1 Depth=1
+	bc	.LBB3_1
+.LBB3_8:
+	li	$a0, -1
+	sw	$a0, 28($sp)
+	bc	.LBB3_9
+.LBB3_9:
+	lw	$a0, 28($sp)
+	addiu	$sp, $sp, 32
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	binarySearch
+.Lfunc_end3:
+	.size	binarySearch, .Lfunc_end3-binarySearch
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	1
+	.type	main,@function
+	.ent	main
+main:                                   # @main
+	.frame	$sp,432,$ra
+	.mask 	0x00000000,0
+	.fmask	0x00000000,0
+	.set	noreorder
+	.set	nomacro
+	.set	noat
+# %bb.0:
+	addiu	$sp, $sp, -432
+	sw	$ra, 428($sp)                   # 4-byte Folded Spill
+	move	$a0, $zero
+	addiu	$a1, $sp, 424
+	sw	$a0, 0($a1)
+	balc	time
+	balc	srand
+	addiu	$a0, $sp, 24
+	sw	$a0, 12($sp)                    # 4-byte Folded Spill
+	li	$a1, 100
+	sw	$a1, 8($sp)                     # 4-byte Folded Spill
+	balc	fillArray
+	lapc.b	$a0, .L.str
+	balc	printf
+	lw	$a1, 8($sp)                     # 4-byte Folded Reload
+                                        # kill: def $a2_nm killed $a0_nm
+	lw	$a0, 12($sp)                    # 4-byte Folded Reload
+	balc	printArray
+	lw	$a0, 12($sp)                    # 4-byte Folded Reload
+	lw	$a1, 8($sp)                     # 4-byte Folded Reload
+	balc	sortArray
+	lapc.b	$a0, .L.str.1
+	balc	printf
+	lw	$a1, 8($sp)                     # 4-byte Folded Reload
+                                        # kill: def $a2_nm killed $a0_nm
+	lw	$a0, 12($sp)                    # 4-byte Folded Reload
+	balc	printArray
+	lapc.b	$a0, .L.str.2
+	balc	printf
+	lapc.b	$a0, .L.str.3
+	addiu	$a1, $sp, 20
+	balc	__isoc99_scanf
+	lw	$a1, 8($sp)                     # 4-byte Folded Reload
+                                        # kill: def $a2_nm killed $a0_nm
+	lw	$a0, 12($sp)                    # 4-byte Folded Reload
+	lw	$a2, 20($sp)
+	balc	binarySearch
+	sw	$a0, 16($sp)
+	lw	$a0, 16($sp)
+	li	$a1, -1
+	beqc	$a0, $a1, .LBB4_2
+	bc	.LBB4_1
+.LBB4_1:
+	lw	$a1, 20($sp)
+	lw	$a2, 16($sp)
+	lapc.b	$a0, .L.str.4
+	balc	printf
+	bc	.LBB4_3
+.LBB4_2:
+	lw	$a1, 20($sp)
+	lapc.b	$a0, .L.str.5
+	balc	printf
+	bc	.LBB4_3
+.LBB4_3:
+	move	$a0, $zero
+	lw	$ra, 428($sp)                   # 4-byte Folded Reload
+	addiu	$sp, $sp, 432
+	jrc	$ra
+	.set	at
+	.set	macro
+	.set	reorder
+	.end	main
+.Lfunc_end4:
+	.size	main, .Lfunc_end4-main
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.4,"aMS",@progbits,1
+	.p2align	2
+.L.str:
+	.asciz	"Original Array:\n"
+	.size	.L.str, 17
+
+	.type	.L.str.1,@object                # @.str.1
+	.p2align	2
+.L.str.1:
+	.asciz	"\nSorted Array:\n"
+	.size	.L.str.1, 16
+
+	.type	.L.str.2,@object                # @.str.2
+	.p2align	2
+.L.str.2:
+	.asciz	"\nEnter a number to search for: "
+	.size	.L.str.2, 32
+
+	.type	.L.str.3,@object                # @.str.3
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str.3:
+	.asciz	"%d"
+	.size	.L.str.3, 3
+
+	.type	.L.str.4,@object                # @.str.4
+	.section	.rodata.str1.4,"aMS",@progbits,1
+	.p2align	2
+.L.str.4:
+	.asciz	"Number %d found at index %d.\n"
+	.size	.L.str.4, 30
+
+	.type	.L.str.5,@object                # @.str.5
+	.p2align	2
+.L.str.5:
+	.asciz	"Number %d not found in the array.\n"
+	.size	.L.str.5, 35
+
+	.type	.L.str.6,@object                # @.str.6
+	.p2align	2
+.L.str.6:
+	.asciz	"%d "
+	.size	.L.str.6, 4
+
+	.type	.L.str.7,@object                # @.str.7
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str.7:
+	.asciz	"\n"
+	.size	.L.str.7, 2
+
+	.ident	"clang version 13.0.0 (https://github.com/MediaTek-Labs/llvm-project.git 591da1c539e7fb4a859b47668b4445d963f6f4f1)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym srand
+	.addrsig_sym time
+	.addrsig_sym fillArray
+	.addrsig_sym printf
+	.addrsig_sym printArray
+	.addrsig_sym sortArray
+	.addrsig_sym __isoc99_scanf
+	.addrsig_sym binarySearch
+	.addrsig_sym rand
+	.text
+
+# CHECK:      Iterations:        300
+# CHECK-NEXT: Instructions:      65400
+# CHECK-NEXT: Total Cycles:      525902
+# CHECK-NEXT: Total uOps:        65400
+
+# CHECK:      Dispatch Width:    2
+# CHECK-NEXT: uOps Per Cycle:    0.12
+# CHECK-NEXT: IPC:               0.12
+# CHECK-NEXT: Block RThroughput: 109.0
+
+
+# CHECK:      Instruction Info:
+# CHECK-NEXT: [1]: #uOps
+# CHECK-NEXT: [2]: Latency
+# CHECK-NEXT: [3]: RThroughput
+# CHECK-NEXT: [4]: MayLoad
+# CHECK-NEXT: [5]: MayStore
+# CHECK-NEXT: [6]: HasSideEffects (U)
+
+# CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -16
+# CHECK-NEXT:  1      1     1.00                  U     sw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a1, 4($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 0($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 4($sp)
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB0_4
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_2
+# CHECK-NEXT:  1      1     1.00                        balc	rand
+# CHECK-NEXT:  1      1     0.50                        li	$a1, 274877907
+# CHECK-NEXT:  1      5     1.00                        muh	$a1, $a0, $a1
+# CHECK-NEXT:  1      1     0.50                        srl	$a2, $a1, 31
+# CHECK-NEXT:  1      1     0.50                        sra	$a1, $a1, 6
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a2, $a1, $a2
+# CHECK-NEXT:  1      1     0.50                  U     sll	$a1, $a2, 4
+# CHECK-NEXT:  1      1     0.50                        lsa	$a1, $a2, $a1, 3
+# CHECK-NEXT:  1      1     0.50                        sll	$a2, $a2, 10
+# CHECK-NEXT:  1      1     0.50                  U     subu	$a1, $a1, $a2
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a0, $a0, $a1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 0($sp)
+# CHECK-NEXT:  1      1     1.00           *            swxs	$a0, $a2($a1)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB0_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 16
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -16
+# CHECK-NEXT:  1      1     1.00                  U     sw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a1, 4($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB1_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 0($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 4($sp)
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB1_4
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB1_2
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 0($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lwxs	$a1, $a1($a0)
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.6
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB1_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 0($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB1_1
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.7
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      2     1.00                  U     lw	$ra, 12($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 16
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -32
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 28($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a1, 24($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 20($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 20($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 24($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a1, $a1, -1
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB2_10
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_2
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 16($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 16($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 24($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 20($sp)
+# CHECK-NEXT:  1      1     0.50                        not	$a1, $a1
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a1, $a1, $a2
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB2_8
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_4
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 28($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 16($sp)
+# CHECK-NEXT:  1      1     0.50                        lsa	$a0, $a2, $a1, 2
+# CHECK-NEXT:  1      2     1.00                  U     lwxs	$a1, $a2($a1)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($a0)
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB2_6
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_5
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 28($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 16($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 28($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 16($sp)
+# CHECK-NEXT:  1      1     0.50                        lsa	$a0, $a2, $a1, 2
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($a0)
+# CHECK-NEXT:  1      1     1.00           *            swxs	$a0, $a2($a1)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 28($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 16($sp)
+# CHECK-NEXT:  1      1     0.50                        lsa	$a1, $a1, $a2, 2
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 4($a1)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_6
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_7
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 16($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 16($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_3
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_9
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 20($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 20($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB2_1
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 32
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -32
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 24($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a1, 20($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a2, 16($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 20($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, -1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        bltc	$a0, $a1, .LBB3_8
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_2
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      1     0.50                  U     subu	$a1, $a1, $a0
+# CHECK-NEXT:  1      1     0.50                        srl	$a2, $a1, 31
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a1, $a1, $a2
+# CHECK-NEXT:  1      1     0.50                        sra	$a1, $a1, 1
+# CHECK-NEXT:  1      1     0.50                  U     addu	$a0, $a0, $a1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 4($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 24($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 4($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 16($sp)
+# CHECK-NEXT:  1      1     1.00                  U     bnec	$a0, $a1, .LBB3_4
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 28($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_9
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 24($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 4($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 16($sp)
+# CHECK-NEXT:  1      1     1.00                        bgec	$a0, $a1, .LBB3_6
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_5
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, 1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 12($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_7
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 4($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$a0, $a0, -1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_7
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_1
+# CHECK-NEXT:  1      1     0.50                  U     li	$a0, -1
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 28($sp)
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB3_9
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 28($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 32
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, -432
+# CHECK-NEXT:  1      1     1.00           *            sw	$ra, 428($sp)
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      1     0.50                        addiu	$a1, $sp, 424
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 0($a1)
+# CHECK-NEXT:  1      1     1.00                        balc	time
+# CHECK-NEXT:  1      1     1.00                        balc	srand
+# CHECK-NEXT:  1      1     0.50                  U     addiu	$a0, $sp, 24
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 12($sp)
+# CHECK-NEXT:  1      1     0.50                  U     li	$a1, 100
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a1, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        balc	fillArray
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      1     1.00                        balc	printArray
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      1     1.00                        balc	sortArray
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.1
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      1     1.00                        balc	printArray
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.2
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.3
+# CHECK-NEXT:  1      1     0.50                  U     addiu	$a1, $sp, 20
+# CHECK-NEXT:  1      1     1.00                        balc	__isoc99_scanf
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 8($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 12($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 20($sp)
+# CHECK-NEXT:  1      1     1.00                        balc	binarySearch
+# CHECK-NEXT:  1      1     1.00                  U     sw	$a0, 16($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a0, 16($sp)
+# CHECK-NEXT:  1      1     0.50                  U     li	$a1, -1
+# CHECK-NEXT:  1      1     1.00                  U     beqc	$a1, $a0, .LBB4_2
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB4_1
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 20($sp)
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a2, 16($sp)
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.4
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB4_3
+# CHECK-NEXT:  1      2     1.00                  U     lw	$a1, 20($sp)
+# CHECK-NEXT:  1      1     0.50                        lapc.b	$a0, .L.str.5
+# CHECK-NEXT:  1      1     1.00                        balc	printf
+# CHECK-NEXT:  1      1     1.00                        bc	.LBB4_3
+# CHECK-NEXT:  1      1     0.50                  U     move	$a0, $zero
+# CHECK-NEXT:  1      2     1.00    *                   lw	$ra, 428($sp)
+# CHECK-NEXT:  1      1     0.50                        addiu	$sp, $sp, 432
+# CHECK-NEXT:  1      1     1.00                  U     jrc	$ra
+
+
+# CHECK:      Resources:
+# CHECK-NEXT: [0]   - I7200Atomic
+# CHECK-NEXT: [1]   - i7200Agen
+# CHECK-NEXT: [2]   - i7200Alu0
+# CHECK-NEXT: [3]   - i7200Alu1
+# CHECK-NEXT: [4]   - i7200Control
+# CHECK-NEXT: [5]   - i7200Ctu
+# CHECK-NEXT: [6]   - i7200GpMulDiv
+# CHECK-NEXT: [7]   - i7200Lsu
+
+
+# CHECK:      Resource pressure per iteration:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    
+# CHECK-NEXT:  -     100.00 29.00  29.00  60.00  60.00  1.00   99.00  
+
+# CHECK:      Resource pressure by instruction:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$sp, $sp, -16
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$ra, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a1, 4($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 0($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 0($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 4($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB0_4
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_2
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	rand
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     li	$a1, 274877907
+# CHECK-NEXT:  -     1.00    -      -      -      -     1.00    -     muh	$a1, $a0, $a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     srl	$a2, $a1, 31
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     sra	$a1, $a1, 6
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addu	$a2, $a1, $a2
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     sll	$a1, $a2, 4
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lsa	$a1, $a2, $a1, 3
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     sll	$a2, $a2, 10
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     subu	$a1, $a1, $a2
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addu	$a0, $a0, $a1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 0($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   swxs	$a0, $a2($a1)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 0($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 0($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB0_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$ra, 12($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$sp, $sp, 16
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$sp, $sp, -16
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$ra, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a1, 4($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 0($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB1_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 0($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 4($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB1_4
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB1_2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 0($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lwxs	$a1, $a1($a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lapc.b	$a0, .L.str.6
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB1_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 0($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 0($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB1_1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lapc.b	$a0, .L.str.7
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$ra, 12($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$sp, $sp, 16
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$sp, $sp, -32
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 28($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a1, 24($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 20($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 20($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 24($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a1, $a1, -1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB2_10
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_2
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 16($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 16($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 24($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 20($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     not	$a1, $a1
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addu	$a1, $a1, $a2
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB2_8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_4
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 28($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 16($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lsa	$a0, $a2, $a1, 2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lwxs	$a1, $a2($a1)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($a0)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB2_6
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_5
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 28($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 16($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 28($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 16($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     lsa	$a0, $a2, $a1, 2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($a0)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   swxs	$a0, $a2($a1)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 28($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 16($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lsa	$a1, $a1, $a2, 2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 4($a1)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_6
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_7
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 16($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 16($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_3
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_9
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 20($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 20($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB2_1
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$sp, $sp, 32
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$sp, $sp, -32
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 24($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a1, 20($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a2, 16($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 20($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a0, $a0, -1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bltc	$a0, $a1, .LBB3_8
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_2
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     subu	$a1, $a1, $a0
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     srl	$a2, $a1, 31
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addu	$a1, $a1, $a2
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     sra	$a1, $a1, 1
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addu	$a0, $a0, $a1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 24($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 16($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bnec	$a0, $a1, .LBB3_4
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 28($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_9
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 24($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 4($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lwxs	$a0, $a1($a0)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 16($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bgec	$a0, $a1, .LBB3_6
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_5
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a0, $a0, 1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 12($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_7
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 4($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$a0, $a0, -1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_7
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     li	$a0, -1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 28($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB3_9
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 28($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$sp, $sp, 32
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$sp, $sp, -432
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$ra, 428($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$a1, $sp, 424
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 0($a1)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	time
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	srand
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$a0, $sp, 24
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 12($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     li	$a1, 100
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a1, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	fillArray
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     lapc.b	$a0, .L.str
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printArray
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	sortArray
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lapc.b	$a0, .L.str.1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printArray
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     lapc.b	$a0, .L.str.2
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lapc.b	$a0, .L.str.3
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     addiu	$a1, $sp, 20
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	__isoc99_scanf
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 8($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 12($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 20($sp)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	binarySearch
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   sw	$a0, 16($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a0, 16($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     li	$a1, -1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     beqc	$a1, $a0, .LBB4_2
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB4_1
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 20($sp)
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a2, 16($sp)
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     lapc.b	$a0, .L.str.4
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB4_3
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$a1, 20($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     lapc.b	$a0, .L.str.5
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     balc	printf
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     bc	.LBB4_3
+# CHECK-NEXT:  -      -      -     1.00    -      -      -      -     move	$a0, $zero
+# CHECK-NEXT:  -     1.00    -      -      -      -      -     1.00   lw	$ra, 428($sp)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -     addiu	$sp, $sp, 432
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     jrc	$ra

--- a/llvm/test/tools/llvm-mca/nanoMIPS/lit.local.cfg
+++ b/llvm/test/tools/llvm-mca/nanoMIPS/lit.local.cfg
@@ -1,0 +1,2 @@
+if not 'Mips' in config.root.targets:
+    config.unsupported = True

--- a/llvm/test/tools/llvm-mca/nanoMIPS/special_instructions.s
+++ b/llvm/test/tools/llvm-mca/nanoMIPS/special_instructions.s
@@ -1,0 +1,136 @@
+# RUN: llvm-mca -mtriple=nanomips -mcpu=i7200 -iterations=300 -enable-misched -misched-postra < %s | FileCheck %s
+
+break 5
+cache 0, 0($a1)
+deret
+di $a0
+ehb
+ei $a1
+eret
+eretnc
+extw $a0, $a1, $a2, 5
+ginvi $a0
+ginvt $a3, 2
+mfc0 $a4, $3, 2
+mfhc0 $a4, $3, 2
+mtc0 $a4, $3, 2
+mthc0 $a4, $3, 2
+pause
+pref 0, 1($a5)
+rdpgpr $a0, $a1
+sdbbp 2
+sigrie 2
+sync
+synci 5($a6)
+syscall 123
+tlbinv
+tlbinvf
+tlbp
+tlbr
+tlbwi
+tlbwr
+wait
+wrpgpr $a0, $a1
+
+
+# CHECK:      Iterations:        300
+# CHECK-NEXT: Instructions:      9300
+# CHECK-NEXT: Total Cycles:      12901
+# CHECK-NEXT: Total uOps:        9300
+
+# CHECK:      Dispatch Width:    2
+# CHECK-NEXT: uOps Per Cycle:    0.72
+# CHECK-NEXT: IPC:               0.72
+# CHECK-NEXT: Block RThroughput: 43.0
+
+
+# CHECK:      Instruction Info:
+# CHECK-NEXT: [1]: #uOps
+# CHECK-NEXT: [2]: Latency
+# CHECK-NEXT: [3]: RThroughput
+# CHECK-NEXT: [4]: MayLoad
+# CHECK-NEXT: [5]: MayStore
+# CHECK-NEXT: [6]: HasSideEffects (U)
+
+# CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
+# CHECK-NEXT:  1      1     1.00                  U     break	5
+# CHECK-NEXT:  1      2     1.00                  U     cache	0, 0($a1)
+# CHECK-NEXT:  1      1     1.00                  U     deret
+# CHECK-NEXT:  1      2     2.00                  U     di	$a0
+# CHECK-NEXT:  1      2     2.00                  U     ehb
+# CHECK-NEXT:  1      2     2.00                  U     ei	$a1
+# CHECK-NEXT:  1      1     1.00                  U     eret
+# CHECK-NEXT:  1      1     1.00                  U     eretnc
+# CHECK-NEXT:  1      1     0.50                  U     extw	$a0, $a1, $a2, 5
+# CHECK-NEXT:  1      1     1.00                  U     ginvi	$a0
+# CHECK-NEXT:  1      2     2.00                  U     ginvt	$a3, 2
+# CHECK-NEXT:  1      2     2.00                  U     mfc0	$a4, $3, 2
+# CHECK-NEXT:  1      2     2.00                  U     mfhc0	$a4, $3, 2
+# CHECK-NEXT:  1      2     2.00                  U     mtc0	$a4, $3, 2
+# CHECK-NEXT:  1      2     2.00                  U     mthc0	$a4, $3, 2
+# CHECK-NEXT:  1      2     2.00                  U     pause
+# CHECK-NEXT:  1      2     1.00                  U     pref	0, 1($a5)
+# CHECK-NEXT:  1      1     0.50                  U     rdpgpr	$a0, $a1
+# CHECK-NEXT:  1      1     1.00                  U     sdbbp	2
+# CHECK-NEXT:  1      1     1.00                  U     sigrie	2
+# CHECK-NEXT:  1      1     1.00                  U     sync
+# CHECK-NEXT:  1      2     1.00                  U     synci	5($a6)
+# CHECK-NEXT:  1      1     1.00                  U     syscall	123
+# CHECK-NEXT:  1      2     2.00                  U     tlbinv
+# CHECK-NEXT:  1      2     2.00                  U     tlbinvf
+# CHECK-NEXT:  1      2     2.00                  U     tlbp
+# CHECK-NEXT:  1      2     2.00                  U     tlbr
+# CHECK-NEXT:  1      2     2.00                  U     tlbwi
+# CHECK-NEXT:  1      2     2.00                  U     tlbwr
+# CHECK-NEXT:  1      2     2.00                  U     wait
+# CHECK-NEXT:  1      1     0.50                  U     wrpgpr	$a0, $a1
+
+
+# CHECK:      Resources:
+# CHECK-NEXT: [0]   - I7200Atomic
+# CHECK-NEXT: [1]   - i7200Agen
+# CHECK-NEXT: [2]   - i7200Alu0
+# CHECK-NEXT: [3]   - i7200Alu1
+# CHECK-NEXT: [4]   - i7200Control
+# CHECK-NEXT: [5]   - i7200Ctu
+# CHECK-NEXT: [6]   - i7200GpMulDiv
+# CHECK-NEXT: [7]   - i7200Lsu
+
+
+# CHECK:      Resource pressure per iteration:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    
+# CHECK-NEXT:  -     3.00   1.50   1.50   43.00  7.00    -     4.00   
+
+# CHECK:      Resource pressure by instruction:
+# CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     break	5
+# CHECK-NEXT:  -     1.00    -      -     1.00    -      -     1.00   cache	0, 0($a1)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     deret
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     di	$a0
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     ehb
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     ei	$a1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     eret
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     eretnc
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     extw	$a0, $a1, $a2, 5
+# CHECK-NEXT:  -      -      -      -     1.00    -      -      -     ginvi	$a0
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     ginvt	$a3, 2
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     mfc0	$a4, $3, 2
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     mfhc0	$a4, $3, 2
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     mtc0	$a4, $3, 2
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     mthc0	$a4, $3, 2
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     pause
+# CHECK-NEXT:  -     1.00    -      -     1.00    -      -     1.00   pref	0, 1($a5)
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     rdpgpr	$a0, $a1
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     sdbbp	2
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     sigrie	2
+# CHECK-NEXT:  -      -      -      -      -      -      -     1.00   sync
+# CHECK-NEXT:  -     1.00    -      -     1.00    -      -     1.00   synci	5($a6)
+# CHECK-NEXT:  -      -      -      -     1.00   1.00    -      -     syscall	123
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbinv
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbinvf
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbp
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbr
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbwi
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     tlbwr
+# CHECK-NEXT:  -      -      -      -     2.00    -      -      -     wait
+# CHECK-NEXT:  -      -     0.50   0.50    -      -      -      -     wrpgpr	$a0, $a1


### PR DESCRIPTION
This PR adds a scheduling model for the i7200 processor based on this implementation in GCC:
https://github.com/MediaTek-Labs/gcc/blob/mips/umips/gcc6_v12/gcc/config/mips/i7200.md

The new model replaces the generic one when `-mcpu=i7200` is set.