### PR TITLE
Pass --relax to linker by default

### DIFF
--- a/clang/lib/Driver/ToolChains/NanoMips.cpp
+++ b/clang/lib/Driver/ToolChains/NanoMips.cpp
@@ -124,7 +124,7 @@ void NanoMipsLinker::ConstructJob(Compilation &C, const JobAction &JA,
     ToolChain.addFastMathRuntimeIfAvailable(Args, CmdArgs);
   }
 
-  if (Args.hasArg(options::OPT_mrelax)) {
+  if (Args.hasArg(options::OPT_mrelax, options::OPT_mno_relax, true)) {
     CmdArgs.push_back("--relax");
   }
 


### PR DESCRIPTION
Pass `--relax` to the linker in clang using the same conditions as passing `+relax` to the compiler back-end.