### PR TITLE
Fix missing tracing around load/store and move opt passes

### DIFF
--- a/llvm/lib/Target/Mips/Mips.h
+++ b/llvm/lib/Target/Mips/Mips.h
@@ -55,6 +55,8 @@ namespace llvm {
   void initializeNMOptimizeJumpTablesPass (PassRegistry&);
   void initializeNanoMipsRegisterReAllocPass(PassRegistry &);
   void initializeRedundantCopyEliminationPass(PassRegistry&);
+  void initializeNMLoadStoreOptPass(PassRegistry&);
+  void initializeNMMoveOptPass(PassRegistry&);
 } // end namespace llvm;
 
 #endif

--- a/llvm/lib/Target/Mips/MipsTargetMachine.cpp
+++ b/llvm/lib/Target/Mips/MipsTargetMachine.cpp
@@ -62,6 +62,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeMipsTarget() {
   initializeMipsPreLegalizerCombinerPass(*PR);
   initializeNMOptimizeJumpTablesPass(*PR);
   initializeRedundantCopyEliminationPass(*PR);
+  initializeNMLoadStoreOptPass(*PR);
+  initializeNMMoveOptPass(*PR);
 }
 
 static std::string computeDataLayout(const Triple &TT, StringRef CPU,

--- a/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/Mips/NanoMipsLoadStoreOptimizer.cpp
@@ -20,7 +20,8 @@
 
 using namespace llvm;
 
-#define NM_LOAD_STORE_OPT_NAME "nanoMIPS load/store optimization pass"
+#define PASS_NAME "nanoMIPS load/store optimization pass"
+#define DEBUG_TYPE "nmloadstoreopt"
 
 static cl::opt<bool>
 DisableNMSaveRestore("disable-nm-save-restore", cl::Hidden, cl::init(false),
@@ -60,7 +61,7 @@ struct NMLoadStoreOpt : public MachineFunctionPass {
   MCRegisterClass RC = MipsMCRegisterClasses[Mips::GPR32NMRegClassID];
 
   NMLoadStoreOpt() : MachineFunctionPass(ID) {}
-  StringRef getPassName() const override { return NM_LOAD_STORE_OPT_NAME; }
+  StringRef getPassName() const override { return PASS_NAME; }
   bool runOnMachineFunction(MachineFunction &Fn) override;
   bool isReturn(MachineInstr &MI);
   bool isStackPointerAdjustment(MachineInstr &MI, bool IsRestore);
@@ -751,6 +752,8 @@ bool NMLoadStoreOpt::generatePCRelative(MachineBasicBlock &MBB) {
 
   return Candidates.size() > 0;
 }
+
+INITIALIZE_PASS(NMLoadStoreOpt, DEBUG_TYPE, PASS_NAME, false, false)
 
 namespace llvm {
 FunctionPass *createNanoMipsLoadStoreOptimizerPass() {

--- a/llvm/lib/Target/Mips/NanoMipsMoveOptimizer.cpp
+++ b/llvm/lib/Target/Mips/NanoMipsMoveOptimizer.cpp
@@ -24,7 +24,8 @@
 
 using namespace llvm;
 
-#define NM_MOVE_OPT_NAME "nanoMIPS move optimization pass"
+#define DEBUG_TYPE "nmmoveopt"
+#define PASS_NAME "nanoMIPS move optimization pass"
 
 static cl::opt<bool>
 DisableNMMoveOpt("disable-nm-move-opt", cl::Hidden, cl::init(false),
@@ -56,7 +57,7 @@ struct NMMoveOpt : public MachineFunctionPass {
   const MipsSubtarget *STI;
   const TargetInstrInfo *TII;
   NMMoveOpt() : MachineFunctionPass(ID) {}
-  StringRef getPassName() const override { return NM_MOVE_OPT_NAME; }
+  StringRef getPassName() const override { return PASS_NAME; }
   bool runOnMachineFunction(MachineFunction &) override;
   bool generateMoveP(MachineBasicBlock &);
   bool generateMoveBalc(MachineBasicBlock &);
@@ -352,6 +353,8 @@ bool NMMoveOpt::generateMoveBalc(MachineBasicBlock &MBB) {
 
   return MoveBalcPairs.size() > 0;
 }
+
+INITIALIZE_PASS(NMMoveOpt, DEBUG_TYPE, PASS_NAME, false, false)
 
 namespace llvm {
 FunctionPass *createNanoMipsMoveOptimizerPass() { return new NMMoveOpt(); }


### PR DESCRIPTION
The move optimisation and load/store optimisation passes were not initialised correctly and so didn't show up in IR dumps with `-print-before-all` / `-print-after-all` etc.