### PR TITLE
nanoMIPS: Fixed segfaulting and not handling R_NANOMIPS_NO_TRAMP properly in exp-relocs.s

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
@@ -336,12 +336,16 @@ unsigned MipsELFObjectWriter::getRelocType(MCContext &Ctx,
                                            const MCFixup &Fixup,
                                            bool IsPCRel) const {
   // Determine the type of the relocation.
-  unsigned Kind = Fixup.getTargetKind();
-  if (Kind >= FirstLiteralRelocationKind)
-    return Kind - FirstLiteralRelocationKind;
 
+  // FIXME: nanoMIPS has got some relocations after FirstLiteralRelocationKind,
+  // this should be fixed somehow
   if (Ctx.getTargetTriple().isNanoMips())
     return getNanoMipsRelocType(Ctx, Target, Fixup, IsPCRel);
+
+  unsigned Kind = Fixup.getTargetKind();
+
+  if (Kind >= FirstLiteralRelocationKind)
+    return Kind - FirstLiteralRelocationKind;
 
   switch (Kind) {
   case FK_NONE:

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
@@ -142,7 +142,10 @@ public:
 
   bool evaluateBranch(const MCInst &Inst, uint64_t Addr, uint64_t Size,
                       uint64_t &Target) const override {
-    unsigned NumOps = Inst.getNumOperands();
+    // unsigned NumOps = Inst.getNumOperands();
+    // Note: Number of operands that are in McInst and in MCInstrDesc don't match
+    // sometimes, at least for the save for nanoMIPS 
+    unsigned NumOps = Info->get(Inst.getOpcode()).getNumOperands();
     if (NumOps == 0)
       return false;
     switch (Info->get(Inst.getOpcode()).operands()[NumOps - 1].OperandType) {

--- a/llvm/test/MC/Mips/nanomips/exp-relocs.s
+++ b/llvm/test/MC/Mips/nanomips/exp-relocs.s
@@ -2,10 +2,10 @@
 #
 # RUN: llvm-mc -filetype=obj -triple nanomips-elf %s -o - \
 # RUN:   | llvm-objdump --triple nanomips-elf -d -r - | FileCheck %s
+	.linkrelax
 	.text
 	.globl foo
 	.set noat
-	.linkrelax
 	.reloc	1f,R_NANOMIPS_JALR32,end # CHECK: R_NANOMIPS_JALR32	end
 1:	jalr	$t9
 	.reloc	1f,R_NANOMIPS_JALR16,end # CHECK: R_NANOMIPS_JALR16	end


### PR DESCRIPTION

Some relocs of nanoMIPS go past FirstLiteralRelocationKind, fixed it in getRelocType of MipsELFObjectWriter 
Save instruction has different num of operands in MCInst and MCInstrDesc, fixed in evaluateBranch of MipsMcInstrAnalysis