### PR TITLE
[nanoMIPS] Fixed exp-relocs.s test failure

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
@@ -336,12 +336,18 @@ unsigned MipsELFObjectWriter::getRelocType(MCContext &Ctx,
                                            const MCFixup &Fixup,
                                            bool IsPCRel) const {
   // Determine the type of the relocation.
-  unsigned Kind = Fixup.getTargetKind();
-  if (Kind >= FirstLiteralRelocationKind)
-    return Kind - FirstLiteralRelocationKind;
 
+  // FIXME: nanoMIPS has got some relocations after FirstLiteralRelocationKind,
+  // so returning Kind - FirstLiteralRelocationKind won't be right here.
+  // Nevertheless, it seems like nanoMIPS doesn't use these literal
+  // relocations, this should be changed if nanoMIPS starts using them.
   if (Ctx.getTargetTriple().isNanoMips())
     return getNanoMipsRelocType(Ctx, Target, Fixup, IsPCRel);
+
+  unsigned Kind = Fixup.getTargetKind();
+
+  if (Kind >= FirstLiteralRelocationKind)
+    return Kind - FirstLiteralRelocationKind;
 
   switch (Kind) {
   case FK_NONE:


### PR DESCRIPTION
llvm/test/MC/Mips/nanomips/exp-relocs.s test was failing due to 
unrecognized NO_TRAMP relocation. This happened because NO_TRAMP
relocation's enum is higher or equal than FirstLiteralRelocationKind
(some other rare nanoMIPS ones as well). When this enum is higher or
equal to FirstLiteralRelocationKind the reloc is differently 
interpretated, in this case returning NONE reloc instead of NO_TRAMP.
Fix for now is just to move the FirstLiteralRelocationKind comparison
after potentially getting nanoMIPS reloc type.