### PR TITLE
Speedup of lld's input section assignment

### DIFF
--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -342,10 +342,27 @@ StringRef InputFile::getNameForScript() const {
   if (archiveName.empty())
     return getName();
 
-  if (nameForScriptCache.empty())
-    nameForScriptCache = (archiveName + Twine(':') + getName()).str();
+  this->initializeCachedArchiveName();
 
   return nameForScriptCache;
+}
+
+StringRef InputFile::getNameForScriptAlreadyCached() const {
+  if (!nameForScriptCache.empty())
+    return nameForScriptCache;
+
+  assert(archiveName.empty() &&
+         "Archive object file names should be cached before this!");
+
+  return getName();
+}
+
+void InputFile::initializeCachedArchiveName() const {
+  assert(!archiveName.empty() && "File should be from an archive file if "
+                                 "initializing the cached archive name");
+
+  if (nameForScriptCache.empty())
+    nameForScriptCache = (archiveName + Twine(':') + getName()).str();
 }
 
 // An ELF object file may contain a `.deplibs` section. If it exists, the

--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -92,6 +92,11 @@ public:
   // Get filename to use for linker script processing.
   StringRef getNameForScript() const;
 
+  StringRef getNameForScriptAlreadyCached() const;
+
+  // Initialize cached archive name for later usage
+  void initializeCachedArchiveName() const;
+
   // Check if a non-common symbol should be extracted to override a common
   // definition.
   bool shouldExtractForCommon(StringRef name);

--- a/lld/ELF/OutputSections.h
+++ b/lld/ELF/OutputSections.h
@@ -45,6 +45,7 @@ public:
 
   uint32_t sectionIndex = UINT32_MAX;
   unsigned sortRank;
+  bool constraintUnsatisfied = false;
 
   uint32_t getPhdrFlags() const;
 


### PR DESCRIPTION
Assigning input sections to output sections is currently single-threaded, which is not a big problem for most of the cases, as
section assignment doesn't take much time. But, in some cases where there are large linker script with many output sections that none of input sections are mapped to, the section assignment can take quite a while.

This patch tries to parallelize this process a bit, simultaneously trying to match multiple input sections with corresponding output sections.